### PR TITLE
Config for use target directory in tests executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,11 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>-XX:MaxPermSize=128m</argLine>
+          <systemPropertyVariables>
+              <buildDirectory>${project.build.directory}</buildDirectory>
+              <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+              <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Adding configuration for use the target directory instead the user tempdir and force headless mode in CI enviroments.
