### PR TITLE
[FIXED JENKINS-20209] Maven plugin sends email notification to null address

### DIFF
--- a/src/main/java/hudson/maven/reporters/MavenMailer.java
+++ b/src/main/java/hudson/maven/reporters/MavenMailer.java
@@ -31,6 +31,7 @@ import hudson.maven.MavenReporterDescriptor;
 import hudson.model.BuildListener;
 import hudson.tasks.MailSender;
 import hudson.tasks.Mailer;
+
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -59,9 +60,17 @@ public class MavenMailer extends MavenReporter {
     }
     
     public String getAllRecipients() {
-    	return this.recipients == null ?
-    			this.mavenRecipients :
-    			this.recipients + " " + this.mavenRecipients; 
+        StringBuilder sb = new StringBuilder();
+        
+        if (this.recipients != null) {
+            sb.append(this.recipients);
+        }
+        if (this.mavenRecipients != null) {
+            sb.append(" ");
+            sb.append(this.mavenRecipients);
+        }
+        
+    	return sb.toString().trim();
     }
 
     @Extension

--- a/src/test/java/hudson/maven/reporters/MavenMailerTest.java
+++ b/src/test/java/hudson/maven/reporters/MavenMailerTest.java
@@ -216,6 +216,36 @@ public class MavenMailerTest {
         assertContainsRecipient(EMAIL_JENKINS_CONFIGURED, message);
         
     }
+    
+    @Test
+    @Bug(20209)
+    public void testRecipientsNotNullAndMavenRecipientsNull () {
+        MavenMailer fixture = new MavenMailer();
+        fixture.recipients = "your-mail@gmail.com";
+        fixture.mavenRecipients = null;
+        
+        assertEquals("your-mail@gmail.com", fixture.getAllRecipients());
+    }
+    
+    @Test
+    @Bug(20209)
+    public void testMavenRecipientsNotNullAndRecipientsNull () {
+        MavenMailer fixture = new MavenMailer();
+        fixture.recipients = null;
+        fixture.mavenRecipients = "your-mail@gmail.com";
+        
+        assertEquals("your-mail@gmail.com", fixture.getAllRecipients());
+    }
+    
+    @Test
+    @Bug(20209)
+    public void testMavenRecipientsAndRecipientsNotNull () {
+        MavenMailer fixture = new MavenMailer();
+        fixture.recipients = "your-mail@gmail.com";
+        fixture.mavenRecipients = "your-other-mail@gmail.com";
+        
+        assertEquals("your-mail@gmail.com your-other-mail@gmail.com", fixture.getAllRecipients());
+    }
 
 	private void assertContainsRecipient(String email, Message message) throws Exception {
 		assert email != null;


### PR DESCRIPTION
Fix: Maven plugin sends email notification to null address
[FIXED JENKINS-20209]
