### PR TITLE
[FIXED JENKINS-13926] Change for skip saving job maven opts, when these are the same as the global maven opts.

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -1041,24 +1041,35 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      */
     public String getMavenOpts() {
         if ((mavenOpts!=null) && (mavenOpts.trim().length()>0)) { 
-            return mavenOpts.replaceAll("[\t\r\n]+"," ");
+            return getFormattedMavenOpts(mavenOpts);
         }
         else {
             String globalOpts = getDescriptor().getGlobalMavenOpts();
             if (globalOpts!=null) {
-                return globalOpts.replaceAll("[\t\r\n]+"," ");
+                return getFormattedMavenOpts(globalOpts);
             }
             else {
                 return globalOpts;
             }
         }
     }
+    
+    private String getFormattedMavenOpts(String mavenOpts) {
+        return mavenOpts == null? null: mavenOpts.replaceAll("[\t\r\n]+"," ");
+    }
 
     /**
-     * Set mavenOpts.
+     * Set mavenOpts. If the new mavenOpts are equals to the global mavenOpts,
+     * job mavenOpts are set to null.
      */
     public void setMavenOpts(String mavenOpts) {
-        this.mavenOpts = mavenOpts;
+        String globalMavenOpts = getFormattedMavenOpts(getDescriptor().getGlobalMavenOpts());
+        
+        if (mavenOpts != null && !getFormattedMavenOpts(mavenOpts).equals(globalMavenOpts)) {
+            this.mavenOpts = mavenOpts;
+        } else {
+            this.mavenOpts = null;
+        }
     }
 
     /**
@@ -1144,7 +1155,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         if(rootPOM!=null && rootPOM.equals("pom.xml"))   rootPOM=null;   // normalization
 
         goals = Util.fixEmpty(req.getParameter("goals").trim());
-        mavenOpts = Util.fixEmpty(req.getParameter("mavenOpts").trim());
+        setMavenOpts(Util.fixEmpty(req.getParameter("mavenOpts").trim()));
         settings = SettingsProvider.parseSettingsProvider(req);
         globalSettings = GlobalSettingsProvider.parseSettingsProvider(req);
 

--- a/src/test/java/hudson/maven/MavenOptsTest.java
+++ b/src/test/java/hudson/maven/MavenOptsTest.java
@@ -122,6 +122,37 @@ public class MavenOptsTest extends HudsonTestCase {
 
         assertLogContains("[hudson.mavenOpt.test=foo]", m.getLastBuild());
     }
+    
+    @Bug(13926)
+    public void testMustnt_store_global_maven_opts_in_job_maven_opts() throws Exception {
+        final String firstGlobalMavenOpts = "first maven opts";
+        final String secondGlobalMavenOpts = "second maven opts";
+        final String jobMavenOpts = "job maven opts";
+        
+        configureDefaultMaven();
+        MavenModuleSet m = createMavenProject();
+        
+        assertNull(m.getMavenOpts());
+        
+        d.setGlobalMavenOpts(firstGlobalMavenOpts);
+        assertEquals(firstGlobalMavenOpts, m.getMavenOpts());
+        
+        m.setMavenOpts(firstGlobalMavenOpts);
+        assertEquals(firstGlobalMavenOpts, m.getMavenOpts());
+        
+        d.setGlobalMavenOpts(secondGlobalMavenOpts);
+        assertEquals(secondGlobalMavenOpts, m.getMavenOpts());
+        
+        m.setMavenOpts(jobMavenOpts);
+        assertEquals(jobMavenOpts, m.getMavenOpts());
+        
+        d.setGlobalMavenOpts(firstGlobalMavenOpts);
+        m.setMavenOpts(firstGlobalMavenOpts);
+        assertEquals(firstGlobalMavenOpts, m.getMavenOpts());
+        
+        d.setGlobalMavenOpts(secondGlobalMavenOpts);
+        assertEquals(secondGlobalMavenOpts, m.getMavenOpts());
+    }
 
 }
 


### PR DESCRIPTION
Change for skip saving job maven opts, when this is the same as the global maven opts.
Now the global maven opts can't be saved accidentaly as job maven opts.

Notice that this PR solve the issue, but don't implement the suggested solution.

Regards.

Marcelo Rebasti
