### PR TITLE
the perform method should be passing the loop-variable 'moduleBuild' to ...

### DIFF
--- a/src/main/java/hudson/maven/MavenTestDataPublisher.java
+++ b/src/main/java/hudson/maven/MavenTestDataPublisher.java
@@ -83,7 +83,7 @@ public class MavenTestDataPublisher extends Recorder {
             List<Data> data = new ArrayList<Data>();
             if (getTestDataPublishers() != null) {
                 for (TestDataPublisher tdp : getTestDataPublishers()) {
-                    Data d = tdp.getTestData(build, launcher, listener, report.getResult());
+                    Data d = tdp.getTestData(moduleBuild, launcher, listener, report.getResult());
                     if (d != null) {
                         data.add(d);
                     }


### PR DESCRIPTION
From the junit-attachements plugin we see a contradiction between the 
- hudson.tasks.junit.TestDataPublisher
- hudson.tasks.junit.TestResultAction.Data

The TestDataPublisher (without this change) is given a _MavenModuleSetBuild_. But when inside the hudson.tasks.junit.TestResultAction.Data.getTestAction(TestObject) calls hudson.tasks.test.TestObject.getOwner() it is given a _MavenBuild_.

When looking at this for loop in MavenTestDataPublisher it seemed natural to pass getTestData the moduleBuild. Otherwise the TestDataPublisher.getTestData is being called with the same MavenModuleSetBuild instance moduleLastBuilds.values().size() times.

The amount of testing I've done upon this change could only be described as anecdotal. Targeted unit tests may be required.
