### PR TITLE
Variable expansion in maven goals

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -668,6 +668,12 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                             return r;
             			}
 
+                        for (Action action : getRootBuild().getActions()) {
+                            if(action instanceof EnvironmentContributingAction){
+                                ((EnvironmentContributingAction) action).buildEnvVars(MavenModuleSetBuild.this, envVars);
+                            }
+                        }
+
                         parsePoms(listener, logger, envVars, mvn, mavenVersion, mavenBuildInformation); // #5428 : do pre-build *before* parsing pom
                         SplittableBuildListener slistener = new SplittableBuildListener(listener);
                         proxies = new HashMap<ModuleName, ProxyImpl2>();
@@ -786,7 +792,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
 
                         
                         final List<MavenArgumentInterceptorAction> argInterceptors = this.getBuild().getActions(MavenArgumentInterceptorAction.class);
-                        
+
 						// find the correct maven goals and options, there might by an action overruling the defaults
                         String goals = project.getGoals(); // default
                         for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {


### PR DESCRIPTION
Hi

I had a Jenkins job, where I needed to calculate goals to be executed in a shell script. So I two pre-build steps:
- shell script
- inject environment variables (EnvInject)

Then I wanted to put that variable into maven goals, like this:

```
-o clean install -pl ${some_variable}
```

This did not work. This change fixes that. 

Would be happy to know if this is ok, or should be fixed in some other way.

Regards
Marcin
