### PR TITLE
[JENKINS-20884] Variable expansion in maven goals

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -668,6 +668,9 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                             return r;
             			}
 
+                        logger.println("prebuilders: " + Joiner.on(", ").join(project.getPrebuilders()));
+                        logger.println("root actions: " + Joiner.on(", ").join(project.getLastBuild().getActions()));
+
                         for (Action action : getRootBuild().getActions()) {
                             if(action instanceof EnvironmentContributingAction){
                                 ((EnvironmentContributingAction) action).buildEnvVars(MavenModuleSetBuild.this, envVars);

--- a/src/test/java/hudson/maven/MavenEnvironmentContributingActionFromBuilderTest.java
+++ b/src/test/java/hudson/maven/MavenEnvironmentContributingActionFromBuilderTest.java
@@ -1,26 +1,8 @@
 package hudson.maven;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.Launcher;
-import hudson.model.Action;
-import hudson.model.BuildListener;
-import hudson.model.EnvironmentContributingAction;
-import hudson.model.InvisibleAction;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Cause;
-import hudson.tasks.BuildWrapper;
-import hudson.tasks.BuildWrapperDescriptor;
-import hudson.tasks.Builder;
-import hudson.util.ArgumentListBuilder;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-
-import net.sf.json.JSONObject;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -29,34 +11,36 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.StaplerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Cause;
+import hudson.model.EnvironmentContributingAction;
+import hudson.model.InvisibleAction;
+import hudson.model.Result;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.ArgumentListBuilder;
+import net.sf.json.JSONObject;
 
 /**
  * This test case verifies that a maven build also takes EnvironmentContributingAction into account to resolve variables on the command line
  * 
  * @see hudson.model.EnvironmentContributingAction
- * @author Dominik Bartholdi (imod)
  * @author Marcin Cylke (mcl)
  */
 public class MavenEnvironmentContributingActionFromBuilderTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
-
-    @Test
-    @Bug(17555)
-    public void envVariableFromEnvironmentContributingActionMustBeAvailableInMavenModuleSetBuild() throws Exception {
-        j.jenkins.getInjector().injectMembers(this);
-
-        final MavenModuleSet p = j.createMavenProject("mvn");
-
-        p.setMaven(j.configureMaven3().getName());
-        p.setScm(new ExtractResourceSCM(getClass().getResource("maven3-project.zip")));
-        p.setGoals("initialize -Dval=${KEY}");
-
-        p.getBuildWrappersList().add(new TestMvnBuildWrapper("-Dval=MY_VALUE"));
-
-        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new Cause.UserIdCause()).get());
-    }
 
     @Test
     @Bug(20844)
@@ -69,8 +53,10 @@ public class MavenEnvironmentContributingActionFromBuilderTest {
         p.setScm(new ExtractResourceSCM(getClass().getResource("maven3-project.zip")));
         p.setGoals("initialize -Dval=${KEY}");
 
-        p.getPrebuilders().add(new TestMvnBuilder("-Dval=MY_VALUE", "MY_VALUE"));
-        //p.getBuildWrappersList().add(new TestMvnBuildWrapper("-Dval=MY_VALUE"));
+        String keyValue = "MY_VALUE";
+
+        p.getPrebuilders().add(new TestMvnBuilder(keyValue));
+        p.getBuildWrappersList().add(new AssertingBuildWrapper("-Dval=" + keyValue));
 
         j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new Cause.UserIdCause()).get());
     }
@@ -106,7 +92,8 @@ public class MavenEnvironmentContributingActionFromBuilderTest {
         @Override
         public ArgumentListBuilder intercept(ArgumentListBuilder cli, MavenModuleSetBuild arg1) {
             String all = cli.toString();
-            Assert.assertTrue(containsString + " was not found in the goals arguments", all.contains(containsString));
+            Assert.assertTrue(containsString + " was not found in the goals arguments(" + all + ")",
+                all.contains(containsString));
             return cli;
         }
 
@@ -117,18 +104,13 @@ public class MavenEnvironmentContributingActionFromBuilderTest {
     }
 
     /**
-     * This wrapper adds a EnvironmentContributingAction to the build (see TestAction) and also adds the MvnCmdLineVerifier to the build to test whether the variable really got replaced
+     * This wrapper adds MvnCmdLineVerifier to the build to test whether the variable really got replaced
      */
-    public static class TestMvnBuildWrapper extends BuildWrapper {
+    public static class AssertingBuildWrapper extends BuildWrapper {
         private String containsString;
 
-        public TestMvnBuildWrapper(String expectedString) {
+        public AssertingBuildWrapper(String expectedString) {
             this.containsString = expectedString;
-        }
-
-        @Override
-        public Collection<? extends Action> getProjectActions(AbstractProject job) {
-            return Collections.singletonList(new TestAction("KEY", "MY_VALUE"));
         }
 
         @Override
@@ -136,40 +118,24 @@ public class MavenEnvironmentContributingActionFromBuilderTest {
 
             build.addAction(new MvnCmdLineVerifier(containsString));
 
-            return new Environment() {
-            };
-        }
-
-        @Extension
-        public static class TestMvnBuildWrapperDescriptor extends BuildWrapperDescriptor {
-            @Override
-            public boolean isApplicable(AbstractProject<?, ?> project) {
-                return true;
-            }
-
-            @Override
-            public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public String getDisplayName() {
-                return this.getClass().getName();
-            }
+            return new Environment() { };
         }
     }
 
+    /**
+     * This builder returns an action with variable replacement to build process
+     */
     public static class TestMvnBuilder extends Builder {
 
-        private final String expectedString;
         private final String envVariableValue;
 
-        public TestMvnBuilder(String expectedString, String envVariableValue) {
-            this.expectedString = expectedString;
+        public TestMvnBuilder(String envVariableValue) {
             this.envVariableValue = envVariableValue;
         }
 
-
+        @Override
+        public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+            return Collections.singletonList(new TestAction("KEY", envVariableValue));
+        }
     }
-
 }


### PR DESCRIPTION
I had a Jenkins job, where I needed to calculate goals to be executed in a shell script. So I two pre-build steps:
- shell script
- inject environment variables (EnvInject)

Then I wanted to put that variable into maven goals, like this:

```
-o clean install -pl ${some_variable}
```

This did not work. This change fixes that.

Would be happy to know if this is ok, or should be fixed in some other way.

Regards
Marcin
