### PR TITLE
SOAPUI Extension | Change of groupIds

### DIFF
--- a/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -52,8 +52,9 @@ enum TestMojo {
             
     GWT_MAVEN_PLUGIN("org.codehaus.mojo", "gwt-maven-plugin", "test","reportsDirectory","1.2"),
     
-    MAVEN_SOAPUI_PLUGIN("eviware", "maven-soapui-plugin", "test", "outputFolder"),
-    MAVEN_SOAPUI_PRO_PLUGIN("eviware", "maven-soapui-pro-plugin", "test","outputFolder"),
+    MAVEN_SOAPUI_PLUGIN("com.smartbear.soapui", "soapui-maven-plugin", "test", "outputFolder"),
+    MAVEN_SOAPUI_PRO_PLUGIN("com.smartbear.soapui", "soapui-pro-maven-plugin", "test","outputFolder"),
+    MAVEN_SOAPUI_EXTENSION_PLUGIN("com.github.redfish4ktc.soapui", "maven-soapui-extension-plugin", "test","outputFolder"),
     
     JASMINE("com.github.searls","jasmine-maven-plugin","test",null) {
         @Override


### PR DESCRIPTION
- According to http://www.soapui.org/Test-Automation/maven-2x.html the groupId has been changed from eviware to com.smartbear.soapui and the artifactId from maven-soapui-plugin and maven-soapui-pro-plugin to soapui-maven-plugin and soapui-pro-maven-plugin
- It would also be great if the maven-soapui-extension-plugin could be supproted https://github.com/redfish4ktc/maven-soapui-extension-plugin/wiki
