### PR TITLE
SOAPUI Extension | Change of groupIds

### DIFF
--- a/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
+++ b/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
@@ -147,7 +147,7 @@ public class SurefireArchiverDetectTestMojosTest {
     
     @Test
     public void shouldDetectSoapUiMavenPlugin() {
-        MojoInfoBuilder builder = mojoBuilder("eviware", "maven-soapui-plugin", "test");
+        MojoInfoBuilder builder = mojoBuilder("com.smartbear.soapui", "soapui-maven-plugin", "test");
         
         MojoInfo mojo = builder.build();
         assertTrue(this.surefireArchiver.isTestMojo(mojo));
@@ -158,7 +158,18 @@ public class SurefireArchiverDetectTestMojosTest {
     
     @Test
     public void shouldDetectSoapUiProMavenPlugin() {
-        MojoInfoBuilder builder = mojoBuilder("eviware", "maven-soapui-pro-plugin", "test");
+        MojoInfoBuilder builder = mojoBuilder("com.smartbear.soapui", "soapui-pro-maven-plugin", "test");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skip", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+
+    @Test
+    public void shouldDetectSoapUiExtensionMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("com.github.redfish4ktc.soapui", "maven-soapui-extension-plugin", "test");
         
         MojoInfo mojo = builder.build();
         assertTrue(this.surefireArchiver.isTestMojo(mojo));


### PR DESCRIPTION
- According to http://www.soapui.org/Test-Automation/maven-2x.html the groupId has been changed from eviware to com.smartbear.soapui and the artifactId from maven-soapui-plugin and maven-soapui-pro-plugin to soapui-maven-plugin and soapui-pro-maven-plugin
- It would also be great if the maven-soapui-extension-plugin could be supproted https://github.com/redfish4ktc/maven-soapui-extension-plugin/wiki
