### PR TITLE
JENKINS-4861: Fix post-build deployment of Maven artifacts with scpexe-type repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,20 @@ THE SOFTWARE.
       <url>http://www.opensource.org/licenses/mit-license.php</url>
     </license>
   </licenses>
+  
+  <dependencyManagement>
+    <dependencies>
+      <!-- Newer version of plexus-utils is required for artifact deployment to 
+           work using scpexe wagon (see JENKINS-4861). This may be removed when
+           the effective version of the transitive plexus-utils dependency is 3.0.16+. -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.0.17</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Use newer version of transitive plexus-utils dependency that allows to correctly deploy artifacts using scpexe (see https://issues.jenkins-ci.org/browse/JENKINS-4861).
