### PR TITLE
run a full build if build was triggered by upstream (snapshot dependency)

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -779,8 +779,9 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                         // then do the Maven incremental build commands.
                         // If there are no changed modules, we're building everything anyway.
                         boolean maven2_1orLater = new ComparableVersion (mavenVersion).compareTo( new ComparableVersion ("2.1") ) >= 0;
-                        boolean needsFullBuild = getPreviousCompletedBuild() != null &&
-                            getPreviousCompletedBuild().getAction(NeedsFullBuildAction.class) != null;
+                        boolean needsFullBuild = getPreviousCompletedBuild() != null
+                                && getPreviousCompletedBuild().getAction(NeedsFullBuildAction.class) != null
+                                && getCause(UpstreamCause.class) != null;
                         if (project.isIncrementalBuild()) {
                             if (!needsFullBuild && maven2_1orLater && !changedModules.isEmpty()) {
                                 margs.add("-amd");


### PR DESCRIPTION
Given a maven job is configured for incremental build + snapshot trigger
When both SCM changes are detected, + a snapshot has been rebuilt, two builds are scheduled. If queue is already full, those two scheduled builds are merged in queue.
As a result, incremental build will rebuild maven modules affected by SCM changes, but ignore snapshot dependency updates that would have required a full build.

Proposed change is to detect the build cause includes UpstreamCause, not just SCMTriggerCause, and then force a full build.
