### PR TITLE
Add support for Maven 3.2 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <mavenInterceptorsVersion>1.5</mavenInterceptorsVersion>
+    <mavenInterceptorsVersion>1.6-SNAPSHOT</mavenInterceptorsVersion>
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>0.9.0.M3</aetherVersion>
@@ -143,6 +143,11 @@ THE SOFTWARE.
       <artifactId>maven31-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main.maven</groupId>
+      <artifactId>maven32-agent</artifactId>
+      <version>${mavenInterceptorsVersion}</version>
+    </dependency>
     
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
@@ -162,6 +167,11 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven31-interceptor</artifactId>
+      <version>${mavenInterceptorsVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main.maven</groupId>
+      <artifactId>maven32-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/maven/Maven32ProcessFactory.java
+++ b/src/main/java/hudson/maven/Maven32ProcessFactory.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Olivier Lamy
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.maven;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.remoting.Channel;
+import hudson.tasks.Maven.MavenInstallation;
+import jenkins.maven3.agent.Maven32Main;
+import jenkins.security.MasterToSlaveCallable;
+
+import org.jvnet.hudson.maven3.launcher.Maven32Interceptor;
+import org.jvnet.hudson.maven3.listeners.HudsonMavenExecutionResult;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * {@link hudson.maven.AbstractMavenProcessFactory} for Maven 3.2.x
+ *
+ * @author Olivier Lamy
+ */
+public class Maven32ProcessFactory extends Maven3ProcessFactory
+{
+
+    Maven32ProcessFactory( MavenModuleSet mms, AbstractMavenBuild<?, ?> build, Launcher launcher, EnvVars envVars,
+                           String mavenOpts, FilePath workDir ) {
+        super( mms, build, launcher, envVars, mavenOpts, workDir );
+    }
+
+    @Override
+    protected String getMainClassName()
+    {
+        return Maven32Main.class.getName();
+    }
+
+    @Override
+    protected String getMavenAgentClassPath(MavenInstallation mvn, FilePath slaveRoot, BuildListener listener) throws IOException, InterruptedException {
+        String classWorldsJar = getLauncher().getChannel().call(new Maven3ProcessFactory.GetClassWorldsJar(mvn.getHome(),listener));
+        String path = classPathEntry(slaveRoot, Maven32Main.class, "maven32-agent", listener) +
+            (getLauncher().isUnix()?":":";")+classWorldsJar;
+
+        // TODO this configurable??
+        path += (getLauncher().isUnix()?":":";")+mvn.getHomeDir().getPath()+"/conf/logging";
+
+        return path;
+    }
+
+    @Override
+    protected void applyPlexusModuleContributor(Channel channel, AbstractMavenBuild<?, ?> context) throws InterruptedException, IOException {
+        channel.call(new InstallPlexusModulesTask(context));
+    }
+
+    private static final class InstallPlexusModulesTask extends MasterToSlaveCallable<Void,IOException>
+    {
+        PlexusModuleContributor c;
+
+        public InstallPlexusModulesTask(AbstractMavenBuild<?, ?> context) throws IOException, InterruptedException {
+            c = PlexusModuleContributorFactory.aggregate(context);
+        }
+
+        public Void call() throws IOException {
+            Maven32Main.addPlexusComponents( c.getPlexusComponentJars().toArray( new URL[0] ) );
+            return null;
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+    
+    @Override
+    protected String getMavenInterceptorClassPath(MavenInstallation mvn, FilePath slaveRoot, BuildListener listener) throws IOException, InterruptedException {
+        return classPathEntry(slaveRoot, Maven32Interceptor.class, "maven32-interceptor", listener);
+    }
+
+    protected String getMavenInterceptorCommonClassPath(MavenInstallation mvn, FilePath slaveRoot, BuildListener listener) throws IOException, InterruptedException {
+        return classPathEntry(slaveRoot, HudsonMavenExecutionResult.class, "maven3-interceptor-commons", listener);
+    }
+
+
+}

--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -55,6 +55,8 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.DescribableList;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.maven3.agent.Maven31Main;
+import jenkins.maven3.agent.Maven32Main;
+
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ReactorManager;
@@ -63,6 +65,7 @@ import org.apache.maven.monitor.event.EventDispatcher;
 import org.apache.maven.project.MavenProject;
 import org.jvnet.hudson.maven3.agent.Maven3Main;
 import org.jvnet.hudson.maven3.launcher.Maven31Launcher;
+import org.jvnet.hudson.maven3.launcher.Maven32Launcher;
 import org.jvnet.hudson.maven3.launcher.Maven3Launcher;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
@@ -86,9 +89,10 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
-import jenkins.model.ArtifactManager;
 
+import javax.annotation.CheckForNull;
+
+import jenkins.model.ArtifactManager;
 import jenkins.mvn.SettingsProvider;
 
 /**
@@ -813,9 +817,13 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                     LOGGER.fine( "using maven 3 " + mavenVersion );
                     factory = new Maven3ProcessFactory( getParent().getParent(), MavenBuild.this, launcher, envVars, getMavenOpts(listener, envVars), null );
                     break;
-                default:
+                case MAVEN_3_1:
                     LOGGER.fine( "using maven 3 " + mavenVersion );
                     factory = new Maven31ProcessFactory( getParent().getParent(), MavenBuild.this, launcher, envVars, getMavenOpts(listener, envVars), null );
+                    break;
+                default:
+                    LOGGER.fine( "using maven 3 " + mavenVersion );
+                    factory = new Maven32ProcessFactory( getParent().getParent(), MavenBuild.this, launcher, envVars, getMavenOpts(listener, envVars), null );
 
             }
 
@@ -901,9 +909,13 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                     request.maven3MainClass = Maven3Main.class;
                     request.maven3LauncherClass = Maven3Launcher.class;
                     break;
-                default:
+                case MAVEN_3_1:
                     request.maven3MainClass = Maven31Main.class;
                     request.maven3LauncherClass = Maven31Launcher.class;
+                    break;
+                default:
+                    request.maven3MainClass = Maven32Main.class;
+                    request.maven3LauncherClass = Maven32Launcher.class;
             }
 
             return request;

--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -97,9 +97,11 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.codehaus.plexus.util.PathTool;
 
 import jenkins.maven3.agent.Maven31Main;
+import jenkins.maven3.agent.Maven32Main;
 
 import org.jvnet.hudson.maven3.agent.Maven3Main;
 import org.jvnet.hudson.maven3.launcher.Maven31Launcher;
+import org.jvnet.hudson.maven3.launcher.Maven32Launcher;
 import org.jvnet.hudson.maven3.launcher.Maven3Launcher;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -744,12 +746,19 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                                 maven3MainClass = Maven3Main.class;
                                 maven3LauncherClass = Maven3Launcher.class;
                                 break;
-                            default:
+                            case MAVEN_3_1:
                                 LOGGER.fine( "using maven 3 " + mavenVersion );
                                 factory = new Maven31ProcessFactory( project, MavenModuleSetBuild.this, launcher, envVars, mavenOpts,
                                                                     pom.getParent() );
                                 maven3MainClass = Maven31Main.class;
                                 maven3LauncherClass = Maven31Launcher.class;
+                                break;
+                            default:
+                                LOGGER.fine( "using maven 3 " + mavenVersion );
+                                factory = new Maven32ProcessFactory( project, MavenModuleSetBuild.this, launcher, envVars, mavenOpts,
+                                                                    pom.getParent() );
+                                maven3MainClass = Maven32Main.class;
+                                maven3LauncherClass = Maven32Launcher.class;
                         }
 
                         process = MavenBuild.mavenProcessCache.get( launcher.getChannel(), slistener, factory);

--- a/src/main/java/hudson/maven/MavenUtil.java
+++ b/src/main/java/hudson/maven/MavenUtil.java
@@ -299,7 +299,13 @@ public class MavenUtil {
             return MavenVersion.MAVEN_3_0_X;
         }
 
-        return MavenVersion.MAVEN_3_1;
+        ComparableVersion maven3_2_0 = new ComparableVersion("3.2.0");
+
+        if (mavenCurrent.compareTo( maven3_1_0 ) >= 0 && mavenCurrent.compareTo( maven3_2_0 ) < 0){
+            return MavenVersion.MAVEN_3_1;
+        }
+
+        return MavenVersion.MAVEN_3_2;
 
     }
 
@@ -318,7 +324,7 @@ public class MavenUtil {
     }
 
     public enum MavenVersion {
-        MAVEN_2,MAVEN_3_0_X,MAVEN_3_1;
+        MAVEN_2,MAVEN_3_0_X,MAVEN_3_1,MAVEN_3_2;
     }
     
 


### PR DESCRIPTION
Adds support for multi-threaded Maven 3.2 builds - requires https://github.com/jenkinsci/maven-interceptors/pull/5 to be merged first into the maven-interceptors module.
