### PR TITLE
WIP - [JENKINS-26391] Remove getAssignedLabel and replace with getSameNodeConstraint method

### DIFF
--- a/src/main/java/hudson/maven/MavenModule.java
+++ b/src/main/java/hudson/maven/MavenModule.java
@@ -456,10 +456,8 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
      * so it always needs to be built on the same slave as the parent.
      */
     @Override
-    public Label getAssignedLabel() {
-        Node n = getParent().getLastBuiltOn();
-        if(n==null) return null;
-        return n.getSelfLabel();
+    public Object getSameNodeConstraint() {
+        return getRootProject();
     }
 
     /**


### PR DESCRIPTION
Replace getAssignedLabel operation with getSameNodeConstraint and use the root parent project as the constraint. This should improve performance by not performing a lazy loading operation when viewing builds from a label.

@reviewbybees - WIP because I need to write a test unit.