### PR TITLE
[JENKINS-25406] Downgrade ISE to log warning

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -495,6 +495,10 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
         }
 
         public void setResult(Result result) {
+            if (!isBuilding()) {
+                LOGGER.log(Level.WARNING, "JENKINS-25406: illegal attempt to change result from {0} to {1} after {2} finished building", new Object[] {getResult(), result, MavenBuild.this});
+                return;
+            }
             MavenBuild.this.setResult(result);
         }
 


### PR DESCRIPTION
[JENKINS-25406](https://issues.jenkins-ci.org/browse/JENKINS-25406)

Under circumstances yet to be identified, the Maven plugin sometimes tries to set the build result after the build is `COMPLETED`, which is illegal. Until 1.586 Jenkins core silently let it do so unless you happened to be running with `-ea`. As of 1.587 this becomes an `IllegalStateException`, which alerted us to the problem but might be breaking more important things (unclear what the impact is). Downgrading this to a warning in the log and just ignore the attempt to change the build result.

@reviewbybees