### PR TITLE
[JENKINS-28147] Perform Environment tearDown if BuildWrapper fails

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -789,12 +789,15 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
             for (BuildWrapper w : mms.getBuildWrappersList()) {
                 Environment e = w.setUp(MavenBuild.this, launcher, listener);
                 if (e == null) {
-                    for(int i = buildEnvironments.size()-1; i>=0; i--) {
-                        Environment environment = buildEnvironments.get(i);
+                    for(final Environment environment : buildEnvironments) {
                         try {
-                        	environment.tearDown(MavenBuild.this, slistener);
-                        } catch (Exception ignored) {
-                        	// exceptions are ignored to give a chance to all environments to tear down
+                            environment.tearDown(MavenBuild.this, slistener);
+                        } catch (Throwable inTearDown) {
+                            // exceptions are ignored to give a chance to all environments to tear down
+                            listener.error("Unable to tear down: " + inTearDown.getMessage());
+                            if (debug) {
+                                inTearDown.printStackTrace(listener.getLogger());
+                            }
                         }
                     }
 

--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -789,6 +789,15 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
             for (BuildWrapper w : mms.getBuildWrappersList()) {
                 Environment e = w.setUp(MavenBuild.this, launcher, listener);
                 if (e == null) {
+                    for(int i = buildEnvironments.size()-1; i>=0; i--) {
+                        Environment environment = buildEnvironments.get(i);
+                        try {
+                        	environment.tearDown(MavenBuild.this, slistener);
+                        } catch (Exception ignored) {
+                        	// exceptions are ignored to give a chance to all environments to tear down
+                        }
+                    }
+
                     return Result.FAILURE;
                 }
                 buildEnvironments.add(e);

--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -899,9 +899,7 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
 
                         // exceptions are ignored to give a chance to all environments to tear down
                         listener.error("Unable to tear down: " + inTearDown.getMessage());
-                        if (debug) {
-                            inTearDown.printStackTrace(listener.getLogger());
-                        }
+                        inTearDown.printStackTrace(listener.getLogger());
                     }
                 }
                 // WARNING The return in the finally clause will trump any return before

--- a/src/test/java/hudson/maven/MavenBuildTest.java
+++ b/src/test/java/hudson/maven/MavenBuildTest.java
@@ -377,7 +377,7 @@ public class MavenBuildTest {
 
         TearingDownBuildWrapper testBuild1Wrapper = new TearingDownBuildWrapper();
         TearingDownBuildWrapper testBuild2Wrapper = new TearingDownBuildWrapper();
-		m.getBuildWrappersList().addAll(Arrays.asList(testBuild1Wrapper, testBuild2Wrapper, new FailingBuildWrapper()));
+        m.getBuildWrappersList().addAll(Arrays.asList(testBuild1Wrapper, testBuild2Wrapper, new FailingBuildWrapper()));
 
         j.assertBuildStatus(Result.FAILURE, m.scheduleBuild2(0).get());
 
@@ -410,24 +410,22 @@ public class MavenBuildTest {
     private static class FailingBuildWrapper extends BuildWrapper {
         @Override
         public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-        	return null;
+            return null;
         }
     }
 
     private static class TearingDownBuildWrapper extends BuildWrapper {
         public boolean tearDown;
 
-		@Override
+        @Override
         public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-        	return new Environment() {
-        		public boolean tearDown(AbstractBuild build, BuildListener listener) {
-        			tearDown = true;
+            return new Environment() {
+                public boolean tearDown(AbstractBuild build, BuildListener listener) {
+                    tearDown = true;
 
-        			return true;
-        		}
-        	};
+                    return true;
+                }
+            };
         }
-		
-		
     }
 }


### PR DESCRIPTION
If BuildWrapper fails to setup environment (returns null from the setUp method), other BuildWrappers that have completed setup should be tore down. In the Xvfb plugin I see no other way to perform tear down in the plugin itself, and not performing tear down is causing Xvfb process started by the plugin to remain after a failed (re)build of a Maven module.

See https://issues.jenkins-ci.org/browse/JENKINS-28147.