### PR TITLE
JENKINS-24832 Sets modules to NOT_BUILT if running after abort.

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -651,7 +651,7 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                 MavenBuild.this.execute(new Terminate() {
                     @Override
                     public Result run(BuildListener listener) {
-                        return Result.ABORTED;
+                        return Result.NOT_BUILT;
                     }
                 });
             }

--- a/src/test/java/hudson/maven/MavenBuildTest.java
+++ b/src/test/java/hudson/maven/MavenBuildTest.java
@@ -240,7 +240,7 @@ public class MavenBuildTest {
         assertFalse(build.isBuilding());
 
         j.assertBuildStatus(Result.SUCCESS, getModuleBuild(build, "moduleA"));
-        j.assertBuildStatus(Result.ABORTED, getModuleBuild(build, "moduleB"));
+        j.assertBuildStatus(Result.NOT_BUILT, getModuleBuild(build, "moduleB"));
         j.assertBuildStatus(Result.NOT_BUILT, getModuleBuild(build, "moduleC"));
 
         for (MavenBuild mb: build.getModuleLastBuilds().values()) {


### PR DESCRIPTION
This causes all the modules running after an aborted build to have a status of NOT_BUILT. Ideally they would be labelled aborted, but this causes the entire build to be considered aborted if one module fails in a parallel build, and others are still building.

Please see https://issues.jenkins-ci.org/browse/JENKINS-24832