### PR TITLE
[FIXED JENKINS-4428] MavenProbeAction exposes password parameters

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -848,7 +848,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                         
                         MavenProbeAction mpa=null;
                         try {
-                            mpa = new MavenProbeAction(project,process.channel);
+                            mpa = new MavenProbeAction(project, process.channel, MavenModuleSetBuild.this);
                             addAction(mpa);
                             r = process.call(builder);
                             for (ProxyImpl2 proxy : proxies.values()) {


### PR DESCRIPTION
This fix will try to mask sensitive environment variables and system properties:
* Any parameter value of the build marked as sensitive is masked
* Also, BuildWrappers may add additional vars to mask via makeSensitiveBuildVariables()