### PR TITLE
introduce TcpSocketHostLocator extension point

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <mavenInterceptorsVersion>1.6</mavenInterceptorsVersion>
+    <mavenInterceptorsVersion>1.7-SNAPSHOT</mavenInterceptorsVersion>  <!-- relies on https://github.com/jenkinsci/maven-interceptors/pull/8 -->
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>0.9.0.M3</aetherVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <mavenInterceptorsVersion>1.7-SNAPSHOT</mavenInterceptorsVersion>  <!-- relies on https://github.com/jenkinsci/maven-interceptors/pull/8 -->
+    <mavenInterceptorsVersion>1.7</mavenInterceptorsVersion>  
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>0.9.0.M3</aetherVersion>

--- a/src/main/java/hudson/maven/TcpSocketHostLocator.java
+++ b/src/main/java/hudson/maven/TcpSocketHostLocator.java
@@ -1,0 +1,34 @@
+package hudson.maven;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import jenkins.model.Jenkins;
+
+import javax.annotation.CheckForNull;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Identify the Host name to use from maven-agent to connect to to jenkins slave agent TCP socket.
+ * <p>
+ * In simple scenarios both slave agent and maven process do live on same host without specific network
+ * constraints, but for some virtualization usages maven process just can't bind a socket on wildcard
+ * host network. This extension give infrastructure plugins a chance to configure the adequate hostname.
+ * to handle such network constraints
+ *
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public abstract class TcpSocketHostLocator implements ExtensionPoint {
+
+    /**
+     * Try to identify the slave agent TCP socket host name or IP.
+     * @return <code>null</code> if not found or does not apply to this specific implementation
+     * @throws IOException
+     */
+    public abstract @CheckForNull String getTcpSocketHost() throws IOException;
+
+    public static List<TcpSocketHostLocator> all() {
+        return ExtensionList.lookup(TcpSocketHostLocator.class);
+    }
+
+}


### PR DESCRIPTION
relies on https://github.com/jenkinsci/maven-interceptors/pull/8
refactor MAVEN_REMOTE_USEINET so this one is just one-of case communication between maven agent and slave agent do require some netork tweaks