### PR TITLE
SNAPSHOT dependency trigger enhacement

### DIFF
--- a/src/main/java/hudson/maven/AbstractMavenProject.java
+++ b/src/main/java/hudson/maven/AbstractMavenProject.java
@@ -72,7 +72,7 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     		// trigger dependency builds
     		AbstractProject<?,?> downstreamProject = getDownstreamProject();
 
-			boolean ignoreUnsuccessfulUpstreams = ignoreUnsuccessfulUpstreams(downstreamProject);
+    		boolean ignoreUnsuccessfulUpstreams = ignoreUnsuccessfulUpstreams(downstreamProject);
 
     		// if the downstream module depends on multiple modules,
     		// only trigger them when all the upstream dependencies are updated.
@@ -101,14 +101,14 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     				} else
     					ulb = up.getLastSuccessfulBuild();
     				if(ulb==null) {
-						if( !ignoreUnsuccessfulUpstreams ) {
-							// if no usable build is available from the upstream,
-							// then we have to wait at least until this build is ready
-							listener.getLogger().println("Not triggering " + ModelHyperlinkNote.encodeTo(downstreamProject) + " because another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build");
-							return false;
-						} else {
-							listener.getLogger().println("Another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build but " + ModelHyperlinkNote.encodeTo(downstreamProject)+ " is configured to ignore this.");
-						}
+    					if( !ignoreUnsuccessfulUpstreams ) {
+    						// if no usable build is available from the upstream,
+    						// then we have to wait at least until this build is ready
+    						listener.getLogger().println("Not triggering " + ModelHyperlinkNote.encodeTo(downstreamProject) + " because another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build");
+    						return false;
+    					} else {
+    						listener.getLogger().println("Another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build but " + ModelHyperlinkNote.encodeTo(downstreamProject)+ " is configured to ignore this.");
+    					}
     				}
 
     				// if no record of the relationship in the last build
@@ -118,9 +118,9 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     				int n = dlb.getUpstreamRelationship(up);
     				if(n==-1)   continue;
 
-					if( !ignoreUnsuccessfulUpstreams ) {
-						assert ulb.getNumber() >= n;
-					}
+    				if( !ignoreUnsuccessfulUpstreams ) {
+    					assert ulb.getNumber() >= n;
+    				}
     			}
     		}			    
             // No real need to print a message that downstreamProject is being triggered, since BuildTrigger will note this anyway
@@ -164,29 +164,29 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
 			return false;
 		}
 
-		/**
-		 * Determines wheter upstream without successful builds should prevent downstream build
-		 * scheduling
-		 *
-		 * @param downstreamProject
-		 * @return false -  downstream build should not be scheduled when some of its upstreams has
-		 * 					no successfull builds. Default return.<br>
-		 * 		   true  - 	downstream build may be scheduled even if some or many of its upstreams
-		 * 		   			has no successful builds
-		 */
-		private boolean ignoreUnsuccessfulUpstreams(AbstractProject<?,?> downstreamProject) {
-			MavenModuleSet mavenModuleSet = null;
-			if( downstreamProject instanceof MavenModuleSet ) {
-				mavenModuleSet = (MavenModuleSet)downstreamProject;
-			}
-			if( downstreamProject instanceof MavenModule ) {
-				mavenModuleSet = ((MavenModule)downstreamProject).getParent();
-			}
-			if( mavenModuleSet != null ) {
-				return mavenModuleSet.ignoreUnsuccessfulUpstreams();
-			}
-			return false;
-		}
+    	/**
+    	 * Determines wheter upstream without successful builds should prevent downstream build
+    	 * scheduling
+    	 *
+    	 * @param downstreamProject
+    	 * @return false -  downstream build should not be scheduled when some of its upstreams has
+    	 * 					no successfull builds. Default return.<br>
+    	 * 		   true  - 	downstream build may be scheduled even if some or many of its upstreams
+    	 * 		   			has no successful builds
+    	 */
+    	private boolean ignoreUnsuccessfulUpstreams(AbstractProject<?,?> downstreamProject) {
+    		MavenModuleSet mavenModuleSet = null;
+    		if( downstreamProject instanceof MavenModuleSet ) {
+    			mavenModuleSet = (MavenModuleSet)downstreamProject;
+    		}
+    		if( downstreamProject instanceof MavenModule ) {
+    			mavenModuleSet = ((MavenModule)downstreamProject).getParent();
+    		}
+    		if( mavenModuleSet != null ) {
+    			return mavenModuleSet.ignoreUnsuccessfulUpstreams();
+    		}
+    		return false;
+    	}
 
 		private boolean inDownstreamProjects(AbstractProject<?,?> downstreamProject) {
 			DependencyGraph graph = Jenkins.getInstance().getDependencyGraph();

--- a/src/main/java/hudson/maven/AbstractMavenProject.java
+++ b/src/main/java/hudson/maven/AbstractMavenProject.java
@@ -72,6 +72,8 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     		// trigger dependency builds
     		AbstractProject<?,?> downstreamProject = getDownstreamProject();
 
+			boolean ignoreUnsuccessfulUpstreams = ignoreUnsuccessfulUpstreams(downstreamProject);
+
     		// if the downstream module depends on multiple modules,
     		// only trigger them when all the upstream dependencies are updated.
 
@@ -99,10 +101,14 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     				} else
     					ulb = up.getLastSuccessfulBuild();
     				if(ulb==null) {
-    					// if no usable build is available from the upstream,
-    					// then we have to wait at least until this build is ready
-                        listener.getLogger().println("Not triggering " + ModelHyperlinkNote.encodeTo(downstreamProject) + " because another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build");
-    					return false;
+						if( !ignoreUnsuccessfulUpstreams ) {
+							// if no usable build is available from the upstream,
+							// then we have to wait at least until this build is ready
+							listener.getLogger().println("Not triggering " + ModelHyperlinkNote.encodeTo(downstreamProject) + " because another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build");
+							return false;
+						} else {
+							listener.getLogger().println("Another upstream " + ModelHyperlinkNote.encodeTo(up) + " has no successful build but " + ModelHyperlinkNote.encodeTo(downstreamProject)+ " is configured to ignore this.");
+						}
     				}
 
     				// if no record of the relationship in the last build
@@ -112,7 +118,9 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
     				int n = dlb.getUpstreamRelationship(up);
     				if(n==-1)   continue;
 
-    				assert ulb.getNumber()>=n;
+					if( !ignoreUnsuccessfulUpstreams ) {
+						assert ulb.getNumber() >= n;
+					}
     			}
     		}			    
             // No real need to print a message that downstreamProject is being triggered, since BuildTrigger will note this anyway
@@ -152,6 +160,30 @@ public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R exte
                         return false; // do not bother printing messages about other upstreams
                     }
                 }
+			}
+			return false;
+		}
+
+		/**
+		 * Determines wheter upstream without successful builds should prevent downstream build
+		 * scheduling
+		 *
+		 * @param downstreamProject
+		 * @return false -  downstream build should not be scheduled when some of its upstreams has
+		 * 					no successfull builds. Default return.<br>
+		 * 		   true  - 	downstream build may be scheduled even if some or many of its upstreams
+		 * 		   			has no successful builds
+		 */
+		private boolean ignoreUnsuccessfulUpstreams(AbstractProject<?,?> downstreamProject) {
+			MavenModuleSet mavenModuleSet = null;
+			if( downstreamProject instanceof MavenModuleSet ) {
+				mavenModuleSet = (MavenModuleSet)downstreamProject;
+			}
+			if( downstreamProject instanceof MavenModule ) {
+				mavenModuleSet = ((MavenModule)downstreamProject).getParent();
+			}
+			if( mavenModuleSet != null ) {
+				return mavenModuleSet.ignoreUnsuccessfulUpstreams();
 			}
 			return false;
 		}

--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -219,6 +219,12 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
     private boolean ignoreUpstremChanges = false;
 
     /**
+     * If true build will be scheduled when one of the project dependencies is built even if
+     * some other upstreams has no successful builds
+     */
+    private boolean ignoreUnsuccessfulUpstreams = false;
+
+    /**
      * If true, do not archive artifacts to the master.
      */
     private boolean archivingDisabled = false;
@@ -579,6 +585,10 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         return ignoreUpstremChanges;
     }
 
+    public boolean ignoreUnsuccessfulUpstreams() {
+        return ignoreUnsuccessfulUpstreams;
+    }
+
     public boolean runHeadless() {
         return runHeadless;
     }
@@ -646,6 +656,10 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
 
     public void setIgnoreUpstremChanges(boolean ignoreUpstremChanges) {
         this.ignoreUpstremChanges = ignoreUpstremChanges;
+    }
+
+    public void setIgnoreUnsuccessfulUpstreams(boolean ignoreUnsuccessfulUpstreams) {
+        this.ignoreUnsuccessfulUpstreams = ignoreUnsuccessfulUpstreams;
     }
 
     public void setRunHeadless(boolean runHeadless) {
@@ -1206,6 +1220,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         else
             localRepository = null;
         ignoreUpstremChanges = !json.has("triggerByDependency");
+        ignoreUnsuccessfulUpstreams = json.has("ignoreUnsuccessfulUpstreams");
         runHeadless = req.hasParameter("maven.runHeadless");
         incrementalBuild = req.hasParameter("maven.incrementalBuild");
         archivingDisabled = req.hasParameter("maven.archivingDisabled");

--- a/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -34,7 +34,16 @@ THE SOFTWARE.
     <f:optionalBlock name="maven.triggerByDependency"
         help="/plugin/maven-plugin/ignore-upstrem-changes.html"
         title="${%Build whenever a SNAPSHOT dependency is built}"
-        checked="${h.defaultToTrue(!it.ignoreUpstremChanges())}" />
+        checked="${h.defaultToTrue(!it.ignoreUpstremChanges())}">
+      <f:nested>
+          <table width="100%">
+              <f:optionalBlock name="maven.ignoreUnsuccessfulUpstreams"
+                               title="${%Schedule build when some upstream has no successful builds}"
+                               help="/plugin/maven-plugin/ignore-unsuccessful-upstreams.html"
+                               checked="${h.defaultToFalse(it.ignoreUnsuccessfulUpstreams())}"/>
+          </table>
+      </f:nested>
+    </f:optionalBlock>
     <p:config-upstream-pseudo-trigger />
   </p:config-trigger>
 

--- a/src/main/webapp/ignore-unsuccessful-upstreams.html
+++ b/src/main/webapp/ignore-unsuccessful-upstreams.html
@@ -1,0 +1,15 @@
+<div>
+  If checked, Jenkins will schedule build even if some upstream project has no successful builds.
+  If not checked, Jenkins will not schedule build when some SNAPSHOT if any other
+  upstream project has no successful builds on this Jenkins.
+
+  <p>
+  This is convenient for automatically performing continuous integration when project has many upstreams
+  and broking of one prevents from triggering the build of a downstream even when other upstream has been built
+  successfuly. Jenkins may have no knowledge about successful builds for some upstream if builds were cleaned up
+  or was not performed after restarts or upgrades. At the same time this project can be build because
+  the upstream artifacts are present in MAVEN repository.
+
+  <p>
+  This behaviour may trigger extra builds. If this behavior is problematic, uncheck this option.
+</div>


### PR DESCRIPTION
[JENKINS-32635] Add configuration to the SNAPSHOT dependency trigger to allow downstream
project build scheduling while some of it's upstreams has no successful
builds