### PR TITLE
Add jobMain.jelly of transient actions to the Project page

### DIFF
--- a/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
       <st:include page="jobpropertysummaries.jelly" />
 
       <!-- merge fragments from the actions -->
-      <j:forEach var="a" items="${it.actions}">
+      <j:forEach var="a" items="${it.allActions}">
         <st:include page="jobMain.jelly" it="${a}" optional="true" />
       </j:forEach>
 


### PR DESCRIPTION
Unlike in AbstractProject, transient actions can't contribute jelly sections to the Project page in Maven jobs, including the ones created by TransientActionFactory.

Discussion: https://groups.google.com/forum/#!topic/jenkinsci-dev/UtZzYLPQ5JM