### PR TITLE
[JENKINS-34900] getRootBuild() returns itself when there's no parent.

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -176,11 +176,12 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
     }
 
     /**
-     * The same as {@link #getParentBuild()}.
+     * The same as {@link #getParentBuild()} except that returns itself when no parent.
      */
     @Override
     public AbstractBuild<?, ?> getRootBuild() {
-        return getParentBuild();
+        AbstractBuild<?, ?> parent = getParentBuild();
+        return (parent != null) ? parent : this;
     }
 
     /**

--- a/src/test/java/hudson/maven/AbstractMaven3xBuildTest.java
+++ b/src/test/java/hudson/maven/AbstractMaven3xBuildTest.java
@@ -276,6 +276,11 @@ public abstract class AbstractMaven3xBuildTest
         for(MavenModule module : expectedNonBuiltModules) {
             assertEquals(1,module.getLastBuild().getNumber());
         }
+        
+        // AbstractBuild#getRootBuild() never be null.
+        assertNotNull(isolated.getRootBuild());
+        // as there's no parent build, rootBuild is itself.
+        assertEquals(isolated, isolated.getRootBuild());
     }
     
     @Bug(12109)


### PR DESCRIPTION
[JENKINS-34900](https://issues.jenkins-ci.org/browse/JENKINS-34900)

When you trigger a single Maven module build, `MavenBuild#getRootBuild()` returns `null`.
But from javadoc, `AbstractBuild#getRootBuild()` should not return `null`: http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html#getRootBuild%28%29
