### PR TITLE
Make MavenMultiModuleTest#artifactArchiving pass on Windows.

### DIFF
--- a/src/test/java/hudson/maven/MavenMultiModuleTest.java
+++ b/src/test/java/hudson/maven/MavenMultiModuleTest.java
@@ -533,7 +533,7 @@ public class MavenMultiModuleTest {
                 if (f.exists()) {
                     if (f.getRemote().replace('\\', '/').contains("/org/jvnet/hudson/main/test/")) {
                         // Inside the local repository. Hard to know exactly what that path might be, so just mask it out.
-                        f = new FilePath(f.getChannel(), f.getRemote().replaceFirst("^.+(?=[/\\\\]org[/\\\\]jvnet[/\\\\]hudson[/\\\\]main[/\\\\]test[/\\\\])", "…"));
+                        f = new FilePath(f.getChannel(), f.getRemote().replaceFirst("^.+(?=[/\\\\]org[/\\\\]jvnet[/\\\\]hudson[/\\\\]main[/\\\\]test[/\\\\])", "…").replace('\\', '/'));
                     }
                     m.put(e.getKey(), f);
                 } else {


### PR DESCRIPTION
`MavenMultiModuleTest#artifactArchiving` fails on Windows for the difference of path separators:

    artifactArchiving(hudson.maven.MavenMultiModuleTest)  Time elapsed: 53.726 sec  <<< FAILURE!
    org.junit.ComparisonFailure: expected:<...p-1.0-SNAPSHOT.pom=…[/org/jvnet/hudson/main/test/multimod/multimod-top/1.0-SNAPSHOT/]multimod-top-1.0-SNA...> but was:<...p-1.0-SNAPSHOT.pom=…[\org\jvnet\hudson\main\test\multimod\multimod-top\1.0-SNAPSHOT\]multimod-top-1.0-SNA...>
    	at hudson.maven.MavenMultiModuleTest.artifactArchiving(MavenMultiModuleTest.java:495)
