### PR TITLE
[JENKINS-26462] Make plugin compatible with maven builder extraction from the core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.4-SNAPSHOT</jenkins.version>
+    <java.level>7</java.level>
     <mavenInterceptorsVersion>1.7</mavenInterceptorsVersion>  
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
@@ -462,6 +462,11 @@ THE SOFTWARE.
       <artifactId>promoted-builds</artifactId>
       <version>2.23</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>maven-builder-plugin</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,7 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <jenkins.version>2.4-SNAPSHOT</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.13-SNAPSHOT</jenkins.version>
     <mavenInterceptorsVersion>1.7</mavenInterceptorsVersion>  
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>

--- a/src/main/java/hudson/maven/AbstractMavenProject.java
+++ b/src/main/java/hudson/maven/AbstractMavenProject.java
@@ -35,7 +35,6 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.DependencyGraph.Dependency;
-import hudson.tasks.Maven.ProjectWithMaven;
 import hudson.triggers.Trigger;
 
 import java.util.HashSet;
@@ -47,8 +46,7 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R extends AbstractBuild<P,R>> extends AbstractProject<P,R>
-    implements ProjectWithMaven {
+public abstract class AbstractMavenProject<P extends AbstractProject<P,R>,R extends AbstractBuild<P,R>> extends AbstractProject<P,R> {
 
 	protected static class MavenModuleDependency extends Dependency {
 

--- a/src/main/java/hudson/maven/MavenModule.java
+++ b/src/main/java/hudson/maven/MavenModule.java
@@ -728,10 +728,6 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         }
     }
 
-    public MavenInstallation inferMavenInstallation() {
-        return getParent().inferMavenInstallation();
-    }
-
     /**
      * List of active {@link MavenReporter}s configured for this module.
      */

--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -949,10 +949,6 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         return modules.get(rootModule);
     }
 
-    public MavenInstallation inferMavenInstallation() {
-        return getMaven();
-    }
-
     @Override
     protected Set<ResourceActivity> getResourceActivities() {
         final Set<ResourceActivity> activities = new HashSet<ResourceActivity>();

--- a/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
+++ b/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016 CloudBess, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.maven;
+
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.tasks.MavenSelector;
+import hudson.tasks.Maven.MavenInstallation;
+
+@Extension
+public class MavenPluginMavenSelectorImpl extends MavenSelector {
+
+    @Override
+    public boolean isApplicable(Class<? extends Item> itemClass) {
+        if (itemClass.isAssignableFrom(MavenModule.class) || itemClass.isAssignableFrom(MavenModuleSet.class)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public MavenInstallation selectMavenInstallation(Item item) {
+        if (item instanceof MavenModule) {
+            return ((MavenModule) item).getParent().getMaven();
+        } else if (item instanceof MavenModuleSet) {
+            return ((MavenModuleSet) item).getMaven();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
+++ b/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
@@ -28,6 +28,9 @@ import hudson.model.Item;
 import hudson.tasks.MavenSelector;
 import hudson.tasks.Maven.MavenInstallation;
 
+/**
+ * {@link MavenSelector} extension for {@link MavenModule} and {@link MavenModuleSet} {@link Item}s
+ */
 @Extension
 public class MavenPluginMavenSelectorImpl extends MavenSelector {
 

--- a/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
+++ b/src/main/java/hudson/maven/MavenPluginMavenSelectorImpl.java
@@ -36,11 +36,7 @@ public class MavenPluginMavenSelectorImpl extends MavenSelector {
 
     @Override
     public boolean isApplicable(Class<? extends Item> itemClass) {
-        if (itemClass.isAssignableFrom(MavenModule.class) || itemClass.isAssignableFrom(MavenModuleSet.class)) {
-            return true;
-        } else {
-            return false;
-        }
+        return itemClass.isAssignableFrom(MavenModule.class) || itemClass.isAssignableFrom(MavenModuleSet.class);
     }
 
     @Override


### PR DESCRIPTION
[JENKINS-26462](https://issues.jenkins-ci.org/browse/JENKINS-26462)
This is a downstream PR of [PR-2352](https://github.com/jenkinsci/jenkins/pull/2352)

As a consequence os the extraction from the core of the maven builder and the creation of the Maven Builder Plugin, these changes need to be made in order to make the plugin compatible with the new versions of the core.

@reviewbybees esp @jglick @oleg-nenashev 
