### PR TITLE
new android-maven-plugin package support

### DIFF
--- a/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -69,7 +69,8 @@ enum TestMojo {
             "internal-integration-test",null,"3.0.0-alpha-6"),
     ANDROID_MAVEN_PLUGIN("com.jayway.maven.plugins.android.generation2", "android-maven-plugin",
             "internal-integration-test",null,"3.0.0-alpha-6"),
-            
+    ANDROID_MAVEN_PLUGIN_2("com.simpligility.maven.plugins", "android-maven-plugin", "internal-integration-test", null),
+
     GWT_MAVEN_PLUGIN("org.codehaus.mojo", "gwt-maven-plugin", "test","reportsDirectory","1.2"),
     
     MAVEN_SOAPUI_PLUGIN("com.smartbear.soapui", "soapui-maven-plugin", "test", "outputFolder"),


### PR DESCRIPTION
android-maven-plugin was updated and now it has new groupId (com.simpligility.maven).
TestMojo has support for reports directory for older versions of android-maven-plugin, but doesn't have for current version. Pls, add support for new version. So users won't need to declare special property in the project (according to [https://wiki.jenkins-ci.org/display/JENKINS/Building+a+maven2+project#Buildingamaven2project-Example])