### PR TITLE
Java 7 and Jenkins 1.625.1 are now required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
+    <jenkins.version>1.625.1</jenkins.version>
     <java.level>7</java.level>
     <mavenInterceptorsVersion>1.8-SNAPSHOT</mavenInterceptorsVersion>
     <mavenVersion>3.1.0</mavenVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.14</version>
   </parent>
 
   <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->

--- a/src/test/java/hudson/maven/MavenMultiModuleTest.java
+++ b/src/test/java/hudson/maven/MavenMultiModuleTest.java
@@ -70,12 +70,10 @@ public class MavenMultiModuleTest {
         MavenModule mm = mms.getModule("org.jvnet.hudson.main.test.multimod:moduleA");
         j.buildAndAssertSuccess(mms);
         assertEquals(2, mms.getLastStableBuild().number);
-        assertEquals(mms.getLastBuild().getId(), Util.resolveSymlink(new File(mms.getRootDir(), "builds/2")));
         assertEquals("2", Util.resolveSymlink(new File(mms.getRootDir(), "builds/lastStableBuild")));
         assertEquals("builds/lastStableBuild", Util.resolveSymlink(new File(mms.getRootDir(), "lastStable")));
         assertEquals("[lastBuild, lastStableBuild, lastSuccessfulBuild]", permalinks(mms).toString());
         assertEquals(2, mm.getLastStableBuild().number);
-        assertEquals(mm.getLastBuild().getId(), Util.resolveSymlink(new File(mm.getRootDir(), "builds/2")));
         assertEquals("2", Util.resolveSymlink(new File(mm.getRootDir(), "builds/lastStableBuild")));
         assertEquals("builds/lastStableBuild", Util.resolveSymlink(new File(mm.getRootDir(), "lastStable")));
         assertEquals("[lastBuild, lastStableBuild, lastSuccessfulBuild]", permalinks(mm).toString());

--- a/src/test/java/hudson/maven/MavenMultiModuleTest.java
+++ b/src/test/java/hudson/maven/MavenMultiModuleTest.java
@@ -70,11 +70,11 @@ public class MavenMultiModuleTest {
         MavenModule mm = mms.getModule("org.jvnet.hudson.main.test.multimod:moduleA");
         j.buildAndAssertSuccess(mms);
         assertEquals(2, mms.getLastStableBuild().number);
-        assertEquals("2", Util.resolveSymlink(new File(mms.getRootDir(), "builds/lastStableBuild")));
+        assertEquals("2", Util.resolveSymlink(new File(mms.getBuildDir(), "lastStableBuild")));
         assertEquals("builds/lastStableBuild", Util.resolveSymlink(new File(mms.getRootDir(), "lastStable")));
         assertEquals("[lastBuild, lastStableBuild, lastSuccessfulBuild]", permalinks(mms).toString());
         assertEquals(2, mm.getLastStableBuild().number);
-        assertEquals("2", Util.resolveSymlink(new File(mm.getRootDir(), "builds/lastStableBuild")));
+        assertEquals("2", Util.resolveSymlink(new File(mm.getBuildDir(), "lastStableBuild")));
         assertEquals("builds/lastStableBuild", Util.resolveSymlink(new File(mm.getRootDir(), "lastStable")));
         assertEquals("[lastBuild, lastStableBuild, lastSuccessfulBuild]", permalinks(mm).toString());
     }


### PR DESCRIPTION
Maven 3.3.x requires also Java 7
Jenkins 1.625.1 is the first LTS which requires Java 7 (see also https://jenkins.io/blog/2015/04/06/good-bye-java6/ )
Java 6 support for Maven jobs is already impossible for Jenkins >= 1.612
