### PR TITLE
JENKINS-32635: Fix retrieving ignoreUnsuccessfulUpstreams from form

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -1220,7 +1220,12 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         else
             localRepository = null;
         ignoreUpstremChanges = !json.has("triggerByDependency");
-        ignoreUnsuccessfulUpstreams = json.has("ignoreUnsuccessfulUpstreams");
+        if ( !ignoreUpstremChanges ) {
+            JSONObject ignoreUpstremChangesConfig = json.optJSONObject("triggerByDependency");
+            ignoreUnsuccessfulUpstreams = null != ignoreUpstremChangesConfig && ignoreUpstremChangesConfig.has("ignoreUnsuccessfulUpstreams");
+        } else {
+            ignoreUnsuccessfulUpstreams = false;
+        }
         runHeadless = req.hasParameter("maven.runHeadless");
         incrementalBuild = req.hasParameter("maven.incrementalBuild");
         archivingDisabled = req.hasParameter("maven.archivingDisabled");

--- a/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
               <f:optionalBlock name="maven.ignoreUnsuccessfulUpstreams"
                                title="${%Schedule build when some upstream has no successful builds}"
                                help="/plugin/maven-plugin/ignore-unsuccessful-upstreams.html"
-                               checked="${h.defaultToFalse(it.ignoreUnsuccessfulUpstreams())}"/>
+                               checked="${it.ignoreUnsuccessfulUpstreams()}"/>
           </table>
       </f:nested>
     </f:optionalBlock>


### PR DESCRIPTION
submmit

ignoreUnsuccessfulUpstreams parameter should be captured within triggerByDependency
configuration in the form JSON