### PR TITLE
[JENKINS-38736] Dependency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,13 +285,6 @@ THE SOFTWARE.
     </dependency>
     -->
 
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.0-beta</version>
-      <classifier>no_aop</classifier>
-    </dependency>
-
     <!-- JENKINS-10819 : This wagon is safer and more configurable to provide http(s) support -->
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -472,6 +465,12 @@ THE SOFTWARE.
       <artifactId>promoted-builds</artifactId>
       <version>2.23</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>maven-plugin</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Noticed that even in the `maven-plugin-2.13` tag, prior to the merge of #80,

    mvn clean test -Djenkins.version=2.32.1 -Dtest=RedeployPublisherTest\#testTarGzMaven3 -Djava.level=7

passed when it should not have, thus causing `plugin-compat-tester` to miss the fact that 2.13 was incompatible with newer cores. Turns out that the test classpath included _both_ `com.google.inject:guice:jar:4.0:provided` (which would break the old version of Sisu Inject) _and_ `com.google.inject:guice:jar:4.0-beta:provided` (which did not, and came first). The `no_aop` version was explicitly included, despite class loading coming preferentially from Jenkins core, so for no apparent reason (adding to the bloat in `WEB-INF/lib/*.jar`). Furthermore it turns out that this plugin somehow contrived to add an older version of itself to its own test classpath, so even with the explicit dependency deleted, the `no_aop` version was still in the test classpath.

All this ultimately comes down to the longstanding problem that `JenkinsRule` trusts Maven’s crazy transitive dependency resolution, producing a test `${java.class.path}` rather different from what plugins actually use running in live Jenkins.

@recena claims that `acceptance-test-harness`, which _does_ faithfully follow realistic class loading, did not catch the problem either, but that is not so surprising—acceptance tests only cover a small fraction of the functionality that functional tests do, and it is just this one test case out of several hundred that happened to tickle the Sisu Inject code which the Guice 4.0 upgrade broke.

@reviewbybees esp. @kwhetstone