### PR TITLE
[JENKINS-41761] - NullPointerException in Maven32Main 

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -56,6 +56,7 @@ import hudson.util.DescribableList;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.maven3.agent.Maven31Main;
 import jenkins.maven3.agent.Maven32Main;
+import jenkins.maven3.agent.Maven33Main;
 
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.execution.MavenSession;
@@ -66,6 +67,7 @@ import org.apache.maven.project.MavenProject;
 import org.jvnet.hudson.maven3.agent.Maven3Main;
 import org.jvnet.hudson.maven3.launcher.Maven31Launcher;
 import org.jvnet.hudson.maven3.launcher.Maven32Launcher;
+import org.jvnet.hudson.maven3.launcher.Maven33Launcher;
 import org.jvnet.hudson.maven3.launcher.Maven3Launcher;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
@@ -938,9 +940,13 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                     request.maven3MainClass = Maven31Main.class;
                     request.maven3LauncherClass = Maven31Launcher.class;
                     break;
+                case MAVEN_3_2:
+	                request.maven3MainClass = Maven32Main.class;
+	                request.maven3LauncherClass = Maven32Launcher.class;
+	                break;
                 default:
-                    request.maven3MainClass = Maven32Main.class;
-                    request.maven3LauncherClass = Maven32Launcher.class;
+                    request.maven3MainClass = Maven33Main.class;
+                    request.maven3LauncherClass = Maven33Launcher.class;
             }
 
             return request;


### PR DESCRIPTION
Hello guys,

We have a regression there when building a submodule of a Jenkins job, under Maven 3.3.9 we fail I believe because maven-plugin is calling Maven32Main while it is explicitely written on the command line Maven33Main.

So I attached a remote debugger to it and the null pointer is caused at launcher.launch() where launcher is null probably because we are landing in the wrong class set by the builder

**Log:**
Established TCP socket on 42188
<===[JENKINS REMOTING CAPACITY]===>channel started
Executing Maven:  -N -B -s /home/jenkins/config/settings_maven_integration.xml -f /home/jenkins/workspace/SDR_TRUNK_TEST_INTEGRATION/outillage/tests-integration/tests-edr/pom.xml clean deploy -Pjenkins,integration,full-release,integration-modules-deploiements,integration-modules-tests-bouchons,integration-modules-tests-services,integration-deploiements,integration-deploiements-nreg-edr,integration-deploiements-bouchons,integration-deploiements-services,integration-deploiements-elise-verif-start,tests-ti,coverage-ti,tests-tu,coverage-tu,tests-edr,integration-bouchons,tests-soapui,tests-soapui-bouchons,tests-soapui-services
java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:186)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:133)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Started by user a.dovi
Finished: ABORTED
Set build name.
channel stopped
New build name is '#652-IGOR-NREG_EDR'
Variable with name 'BUILD_DISPLAY_NAME' already exists, current value: '#652-IGOR-NREG_EDR', new value: '#652-IGOR-NREG_EDR'
FATAL: java.lang.reflect.InvocationTargetException
java.io.IOException: java.lang.reflect.InvocationTargetException
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:173)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
	at ......remote call to Channel to Maven [/home/xjdkit/put/prd/latest/bin/java, -Xms512m, -Xmx2G, -cp, /home/jenkins/plugins/maven-plugin/WEB-INF/lib/maven33-agent-1.8.1.jar:/home/maven/latest3/boot/plexus-classworlds-2.5.2.jar:/home/maven/latest3/conf/logging, jenkins.maven3.agent.Maven33Main, /home/maven/latest3, /var/cache/jenkins/war/WEB-INF/lib/remoting-3.4.jar, /home/jenkins/plugins/maven-plugin/WEB-INF/lib/maven33-interceptor-1.8.1.jar, /home/jenkins/plugins/maven-plugin/WEB-INF/lib/maven3-interceptor-commons-1.8.1.jar, 42188](Native Method)
	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1537)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:253)
	at hudson.remoting.Channel.call(Channel.java:822)
	at hudson.maven.ProcessCache$MavenProcess.call(ProcessCache.java:161)
	at hudson.maven.MavenBuild$MavenBuildExecution.doRun(MavenBuild.java:880)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
	at hudson.model.Run.execute(Run.java:1729)
	at hudson.maven.MavenBuild.run(MavenBuild.java:270)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:133)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:189)
	... 14 more
Caused by: java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:186)
	... 14 more
Finished: FAILURE