### PR TITLE
[JENKINS-40621, JENKINS-38736] Update lib-jenkins-maven-embedder to 3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.11</version>
+      <version>3.12-SNAPSHOT</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,11 @@ THE SOFTWARE.
         </exclusion>
       </exclusions>      
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-connector-basic</artifactId>
+      <version>${aetherVersion}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ THE SOFTWARE.
     <mavenInterceptorsVersion>1.8.1</mavenInterceptorsVersion>
     <mavenVersion>3.1.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
-    <aetherVersion>0.9.0.M3</aetherVersion>
+    <aetherVersion>1.1.0</aetherVersion>
     <sisuInjectVersion>0.3.3</sisuInjectVersion>
     <wagonVersion>2.4</wagonVersion>
     <!--TODO: change to true after the code cleanup-->


### PR DESCRIPTION
- [x] Fix [JENKINS-40621](https://issues.jenkins-ci.org/browse/JENKINS-40621)
- [x] Update Guice coming from the dependency at least to prevent [JENKINS-38736](https://issues.jenkins-ci.org/browse/JENKINS-38736) . Should finalize the fix started by @jglick  in #87

**Warning**: The Guice update in the library also required update of libs like sisu-plexus (see https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/10). It appears that there are binary compatibility issues, which may potentially impact dependencies of the lib

Changelog: https://github.com/jenkinsci/lib-jenkins-maven-embedder/blob/master/CHANGELOG.md

[Full Diff](https://github.com/jenkinsci/lib-jenkins-maven-embedder/compare/lib-jenkins-maven-embedder-3.11...master)
