### PR TITLE
Remove the message about jenkinsci-users ML

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -924,7 +924,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                 return Result.FAILURE;
             } catch (RuntimeException e) {
                 // bug in the code.
-                e.printStackTrace(listener.error("Processing failed due to a bug in the code. Please report this to the issue tracker"));
+                e.printStackTrace(listener.error("Processing failed due to a bug in the code. Please report this to the issue tracker (https://jenkins.io/redirect/report-an-issue)."));
                 logger.println("project="+project);
                 logger.println("project.getModules()="+project.getModules());
                 logger.println("project.getRootModule()="+project.getRootModule());

--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -924,7 +924,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                 return Result.FAILURE;
             } catch (RuntimeException e) {
                 // bug in the code.
-                e.printStackTrace(listener.error("Processing failed due to a bug in the code. Please report this to jenkinsci-users@googlegroups.com"));
+                e.printStackTrace(listener.error("Processing failed due to a bug in the code. Please report this to the issue tracker"));
                 logger.println("project="+project);
                 logger.println("project.getModules()="+project.getModules());
                 logger.println("project.getRootModule()="+project.getRootModule());


### PR DESCRIPTION
Asking people to simply send this to the ML has FWICT never led to any bugfix. This generally is just sent as is with no details. Better ask people to report issues to avoid spamming the whole users ML.

Last [example](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-users/57D8NoXeHbQ/My0Uo1-GBwAJ) this morning pushed me to finally propose this PR.

@daniel-beck I think you already talked about removing this in the past.