### PR TITLE
[JENKINS-42833] fix typo in image source

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -1459,16 +1459,16 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         static {
             IconSet.icons.addIcon(
                     new Icon("icon-maven-moduleset icon-sm",
-                            "plugin/maven/images/16x16/mavenmoduleset.png", Icon.ICON_SMALL_STYLE));
+                            "plugin/maven-plugin/images/16x16/mavenmoduleset.png", Icon.ICON_SMALL_STYLE));
             IconSet.icons.addIcon(
                     new Icon("icon-maven-moduleset icon-md",
-                            "plugin/maven/images/24x24/mavenmoduleset.png", Icon.ICON_MEDIUM_STYLE));
+                            "plugin/maven-plugin/images/24x24/mavenmoduleset.png", Icon.ICON_MEDIUM_STYLE));
             IconSet.icons.addIcon(
                     new Icon("icon-maven-moduleset icon-lg",
-                            "plugin/maven/images/32x32/mavenmoduleset.png", Icon.ICON_LARGE_STYLE));
+                            "plugin/maven-plugin/images/32x32/mavenmoduleset.png", Icon.ICON_LARGE_STYLE));
             IconSet.icons.addIcon(
                     new Icon("icon-maven-moduleset icon-xlg",
-                            "plugin/maven/images/48x48/mavenmoduleset.png", Icon.ICON_XLARGE_STYLE));
+                            "plugin/maven-plugin/images/48x48/mavenmoduleset.png", Icon.ICON_XLARGE_STYLE));
         }
     }
     


### PR DESCRIPTION
@stephenc introduced a small typo which leads to the following behaviour:
![image](https://cloud.githubusercontent.com/assets/11491375/25696697/6e157486-30b8-11e7-8f67-59a506c49ae1.png)
