### PR TITLE
Maven plugin is not being installed by default starting from Jenkins 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ THE SOFTWARE.
   <packaging>hpi</packaging>
 
   <name>Maven Integration plugin</name>
-  <description>This plug-in provides deep integration of Jenkins and Maven. This functionality used to be part of the Jenkins core.</description>
+  <description>This plug-in provides, for better and for worse, a deep integration of Jenkins and Maven: Automatic triggers between projects depending on SNAPSHOTs, automated configuration of various Jenkins publishers (Junit, ...).</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,7 @@ THE SOFTWARE.
   <packaging>hpi</packaging>
 
   <name>Maven Integration plugin</name>
-  <description>This plug-in provides deep integration of Jenkins and Maven. This functionality used to be part of the Jenkins core.
-  Now it is a plug-in that is installed by default, but can be disabled.</description>
+  <description>This plug-in provides deep integration of Jenkins and Maven. This functionality used to be part of the Jenkins core.</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin</url>
 
   <properties>


### PR DESCRIPTION
The text appears in the Plugin manager, and it may be misleading

@reviewbybees @aheritier 