### PR TITLE
[JENKINS-42549, JENKINS-40621] - Update the Maven Embedder Lib to 3.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.12</version>
+      <version>3.12.1</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>


### PR DESCRIPTION
* [JENKINS-40621](https://issues.jenkins-ci.org/browse/JENKINS-40621) - Prevent leaked file descriptors when invoking `MavenEmbedderUtils#getMavenVersion()`([PR #5](https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/5))
* [JENKINS-42549](https://issues.jenkins-ci.org/browse/JENKINS-42549) - Prevent file access errors in `JARUrlConnection` due to the parallel reading of JAR resources in `MavenEmbedderUtils#getMavenVersion()` (regression in 3.12)

Full diff: https://github.com/jenkinsci/lib-jenkins-maven-embedder/compare/lib-jenkins-maven-embedder-3.12...lib-jenkins-maven-embedder-3.12.1

Changelog: https://github.com/jenkinsci/lib-jenkins-maven-embedder/blob/master/CHANGELOG.md#3121

@reviewbybees @aheritier @olamy @abayer 