### PR TITLE
[JENKINS-13277] Global Environment Variables in Email notification.

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -34,6 +34,7 @@ import hudson.maven.MavenBuild.ProxyImpl2;
 import hudson.maven.reporters.MavenAggregatedArtifactRecord;
 import hudson.maven.reporters.MavenFingerprinter;
 import hudson.maven.reporters.MavenMailer;
+import hudson.maven.util.VariableExpander;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Build;
@@ -1087,7 +1088,8 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
         public void cleanUp(BuildListener listener) throws Exception {
             MavenMailer mailer = project.getReporters().get(MavenMailer.class);
             if (mailer != null) {
-                new MailSender(mailer.getAllRecipients(),
+                final String evaluatedRecipients = new VariableExpander(getBuild(), listener).expand(mailer.getAllRecipients());
+                new MailSender(evaluatedRecipients,
                         mailer.dontNotifyEveryUnstableBuild,
                         mailer.sendToIndividuals).execute(MavenModuleSetBuild.this, listener);
             }

--- a/src/main/java/hudson/maven/reporters/MavenMailer.java
+++ b/src/main/java/hudson/maven/reporters/MavenMailer.java
@@ -29,6 +29,7 @@ import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenReporter;
 import hudson.maven.MavenReporterDescriptor;
+import hudson.maven.util.VariableExpander;
 import hudson.model.BuildListener;
 import hudson.tasks.MailSender;
 import java.io.IOException;
@@ -71,7 +72,8 @@ public class MavenMailer extends MavenReporter {
             if (sendToIndividuals) {
                 LOGGER.log(Level.FINE, "would also include {0}", build.getCulprits());
             }
-            new MailSender(getAllRecipients(),dontNotifyEveryUnstableBuild,sendToIndividuals).execute(build,listener);
+            final String evaluatedRecipients = new VariableExpander(build, listener).expand(getAllRecipients());
+            new MailSender(evaluatedRecipients,dontNotifyEveryUnstableBuild,sendToIndividuals).execute(build,listener);
         }
         return true;
     }

--- a/src/main/java/hudson/maven/util/VariableExpander.java
+++ b/src/main/java/hudson/maven/util/VariableExpander.java
@@ -1,0 +1,31 @@
+package hudson.maven.util;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public final class VariableExpander {
+
+    private static final Logger LOGGER = Logger.getLogger(VariableExpander.class.getName());
+
+    private final AbstractBuild<?, ?> build;
+    private final BuildListener listener;
+
+    public VariableExpander(AbstractBuild<?, ?> build, BuildListener listener) {
+        this.build = build;
+        this.listener = listener;
+    }
+
+    public String expand(final String rawString) {
+        try {
+            return build.getEnvironment(listener).expand(rawString);
+        } catch (IOException e) {
+            LOGGER.fine("Cannot expand the variables in email recipients.");
+        } catch (InterruptedException e) {
+            LOGGER.fine("Cannot expand the variables in email recipients.");
+        }
+        return rawString;
+    }
+}

--- a/src/main/java/hudson/maven/util/VariableExpander.java
+++ b/src/main/java/hudson/maven/util/VariableExpander.java
@@ -1,7 +1,7 @@
 package hudson.maven.util;
 
 import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -11,9 +11,15 @@ public final class VariableExpander {
     private static final Logger LOGGER = Logger.getLogger(VariableExpander.class.getName());
 
     private final AbstractBuild<?, ?> build;
-    private final BuildListener listener;
+    private final TaskListener listener;
 
-    public VariableExpander(AbstractBuild<?, ?> build, BuildListener listener) {
+    public VariableExpander(AbstractBuild<?, ?> build, TaskListener listener) {
+        if (build == null) {
+            throw new IllegalArgumentException("'build' cannot be null.");
+        }
+        if (listener == null) {
+            throw new IllegalArgumentException("'listener' cannot be null.");
+        }
         this.build = build;
         this.listener = listener;
     }

--- a/src/test/java/hudson/maven/reporters/MavenMailerTest.java
+++ b/src/test/java/hudson/maven/reporters/MavenMailerTest.java
@@ -25,9 +25,14 @@ package hudson.maven.reporters;
 
 import static org.junit.Assert.assertEquals;
 
+import hudson.EnvVars;
 import hudson.maven.MavenJenkinsRule;
 import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
 import hudson.model.Result;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
 import hudson.tasks.Mailer;
 import hudson.tasks.Mailer.DescriptorImpl;
 
@@ -35,6 +40,7 @@ import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 
+import hudson.util.DescribableList;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 
@@ -45,6 +51,8 @@ import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.mock_javamail.Mailbox;
+
+import java.util.List;
 
 /**
  * 
@@ -58,6 +66,8 @@ public class MavenMailerTest {
 	private static final String EMAIL_ADMIN = "\"me <me@sun.com>\"";
 	private static final String EMAIL_SOME = "some.email@domain.org";
 	private static final String EMAIL_OTHER = "other.email@domain.org";
+	private static final String ENV_EMAILS_VARIABLE = "ENV_EMAILS";
+	private static final String ENV_EMAILS_VALUE = "another.email@domain.org";
 	
 	@Rule public JenkinsRule j = new MavenJenkinsRule();
 
@@ -217,7 +227,67 @@ public class MavenMailerTest {
         assertContainsRecipient(EMAIL_JENKINS_CONFIGURED, message);
         
     }
-    
+
+    @Test
+    public void testEnvironmentVariableMailBeingReplaced() throws Exception {
+        Jenkins instance = j.getInstance();
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = instance.getGlobalNodeProperties();
+        List<EnvironmentVariablesNodeProperty> envVarsNodePropertyList =
+                globalNodeProperties.getAll(EnvironmentVariablesNodeProperty.class);
+
+        EnvVars envVars = null;
+        if (envVarsNodePropertyList == null || envVarsNodePropertyList.isEmpty()) {
+            EnvironmentVariablesNodeProperty envVarsNodeProperty = new EnvironmentVariablesNodeProperty();
+            globalNodeProperties.add(envVarsNodeProperty);
+            envVars = envVarsNodeProperty.getEnvVars();
+        } else {
+            envVars = envVarsNodePropertyList.get(0).getEnvVars();
+        }
+        envVars.put(ENV_EMAILS_VARIABLE, ENV_EMAILS_VALUE);
+
+        JenkinsLocationConfiguration.get().setAdminAddress(EMAIL_ADMIN);
+        Mailbox someInbox = Mailbox.get(new InternetAddress(EMAIL_SOME));
+        Mailbox otherInbox = Mailbox.get(new InternetAddress(EMAIL_OTHER));
+        Mailbox anotherInbox = Mailbox.get(new InternetAddress(ENV_EMAILS_VALUE));
+        Mailbox jenkinsConfiguredInbox = Mailbox.get(new InternetAddress(EMAIL_JENKINS_CONFIGURED));
+        someInbox.clear();
+        otherInbox.clear();
+        anotherInbox.clear();
+        jenkinsConfiguredInbox.clear();
+
+        ToolInstallations.configureDefaultMaven();
+        MavenModuleSet mms = j.jenkins.createProject(MavenModuleSet.class, "p");
+        mms.setGoals("test");
+        mms.setScm(new ExtractResourceSCM(getClass().getResource("/hudson/maven/JENKINS-1201-module-defined.zip")));
+
+        MavenMailer mailer1 = new MavenMailer();
+        mailer1.recipients = EMAIL_JENKINS_CONFIGURED + " ${" + ENV_EMAILS_VARIABLE + "}";
+        mailer1.perModuleEmail = true;
+        mms.getReporters().add(mailer1);
+
+        MavenModuleSetBuild mmsb = mms.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, mmsb);
+
+        assertEquals(1, someInbox.size());
+        assertEquals(2, anotherInbox.size());
+        assertEquals(2, jenkinsConfiguredInbox.size());
+
+        Message message = otherInbox.get(0);
+        assertEquals(3, message.getAllRecipients().length);
+        assertContainsRecipient(EMAIL_OTHER, message);
+        assertContainsRecipient(EMAIL_JENKINS_CONFIGURED, message);
+
+        message = someInbox.get(0);
+        assertEquals(3, message.getAllRecipients().length);
+        assertContainsRecipient(EMAIL_SOME, message);
+        assertContainsRecipient(EMAIL_JENKINS_CONFIGURED, message);
+
+        message = anotherInbox.get(0);
+        assertEquals(3, message.getAllRecipients().length);
+        assertContainsRecipient(ENV_EMAILS_VALUE, message);
+        assertContainsRecipient(EMAIL_JENKINS_CONFIGURED, message);
+    }
+
     @Test
     @Bug(20209)
     public void testRecipientsNotNullAndMavenRecipientsNull () {

--- a/src/test/java/hudson/maven/util/VariableExpanderTest.java
+++ b/src/test/java/hudson/maven/util/VariableExpanderTest.java
@@ -1,0 +1,76 @@
+package hudson.maven.util;
+
+import hudson.maven.MavenJenkinsRule;
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.*;
+import hudson.tasks.Maven;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.ToolInstallations;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class VariableExpanderTest {
+
+    @Rule
+    public JenkinsRule j = new MavenJenkinsRule();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Map<String, String> envVarsMap = new HashMap<>();
+        envVarsMap.put("ENV_EMAILS", "user@company.com");
+
+        return Arrays.asList(new Object[][] {
+                new Object[]{ null, new HashMap<>(), null },
+                new Object[]{
+                        "john.doe@nowhere.com",
+                        new HashMap<>(),
+                        "john.doe@nowhere.com"
+                },
+                new Object[]{
+                        "Variable JOB_NAME = $JOB_NAME",
+                        envVarsMap,
+                        "Variable JOB_NAME = test"
+                },
+                new Object[]{
+                        "Variable $NOT_IN_ENV_VARS = $NOT_IN_ENV_VARS",
+                        envVarsMap,
+                        "Variable $NOT_IN_ENV_VARS = $NOT_IN_ENV_VARS"
+                }
+        });
+    }
+
+    private final String rawString;
+    private final Map<String, String> envVarsMap;
+    private final String expectedString;
+
+    public VariableExpanderTest(
+            final String rawString,
+            final Map<String, String> envVarsMap,
+            final String expectedString) {
+        this.rawString = rawString;
+        this.envVarsMap = envVarsMap;
+        this.expectedString = expectedString;
+    }
+
+    @Test
+    public void expand() throws Exception {
+        MavenModuleSet m = j.jenkins.createProject(MavenModuleSet.class, "test");
+        Maven.MavenInstallation mavenInstallation = ToolInstallations.configureDefaultMaven();
+        m.setMaven( mavenInstallation.getName() );
+        m.setScm(new ExtractResourceSCM(getClass().getResource("/hudson/maven/several-modules-in-directory.zip")));
+        m.setGoals( "clean validate" );
+
+        MavenModuleSetBuild mmsb =  j.buildAndAssertSuccess(m);
+        assertEquals(expectedString ,new VariableExpander(mmsb, TaskListener.NULL).expand(rawString));
+    }
+
+}


### PR DESCRIPTION
My pull request proposes a way to fix the issue JENKINS-13277 -- 'Global environment variables are not being resolved in Email Notification Recipients list for maven 2/3 projects' --, by creating a class to expand all variables, and then expanding all variables resulting from MavenMailer.getAllRecipients before creating the MailSender object.

Is this solution OK or needs improvements?