### PR TITLE
[JENKINS-46053, JENKINS-45271, JENKINS-46210, JENKINS-46148] - Update HttpClient libraries and Fix Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.12.1</version>
+      <version>3.13-20170915.144243-1</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>2.35</version>
   </parent>
 
   <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>1.1.0</aetherVersion>
     <sisuInjectVersion>0.3.3</sisuInjectVersion>
-    <wagonVersion>2.12</wagonVersion>
+    <wagonVersion>3.0.0</wagonVersion>
     <!--TODO: change to true after the code cleanup-->
     <findbugs.failOnError>false</findbugs.failOnError>
     <!-- well the parent pom could defined an empty one instead of causing failure!! -->
@@ -306,6 +306,11 @@ THE SOFTWARE.
       <version>4.5.3-1.0</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.54.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-file</artifactId>
       <version>${wagonVersion}</version>
@@ -323,6 +328,11 @@ THE SOFTWARE.
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-component-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Comes from the jsch plugin -->
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -346,6 +356,11 @@ THE SOFTWARE.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-classworlds</artifactId>
       <version>2.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
@@ -399,6 +414,11 @@ THE SOFTWARE.
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Core offers commons-codec:commons-codec:1.8, 1.10 will be available on the Maven side anyway -->
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,11 @@ THE SOFTWARE.
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Offered by HttpComponents Client 4.x API plugin and by Maven on the remote side -->
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -380,17 +380,6 @@ THE SOFTWARE.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
       <version>${mavenMinimalVersion}</version>
-      <exclusions>
-        <exclusion>
-          <!--
-            Excluded to solve the upper bounds conflict with the core.
-            Jenkins core bundles 1.8.4 while the Embedder Lib requires Ant 1.9.2
-            The required version is available in Maven Runtime, but there is no sense to ship custom version within the plugin
-          -->
-          <groupId>org.apache.ant</groupId>
-          <artifactId>ant</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>   
     
     
@@ -575,6 +564,15 @@ THE SOFTWARE.
           <!-- we bundle our own version below -->
           <groupId>org.apache.maven.wagon</groupId>
           <artifactId>wagon-webdav</artifactId>
+        </exclusion>
+        <exclusion>
+          <!--
+            Excluded to solve the upper bounds conflict with the core.
+            Jenkins core bundles 1.8.4 while the Embedder Lib requires Ant 1.9.2
+            The required version is available in Maven Runtime, but there is no sense to ship custom version within the plugin
+          -->
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,17 @@ THE SOFTWARE.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
       <version>${mavenMinimalVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!--
+            Excluded to solve the upper bounds conflict with the core.
+            Jenkins core bundles 1.8.4 while the Embedder Lib requires Ant 1.9.2
+            The required version is available in Maven Runtime, but there is no sense to ship custom version within the plugin
+          -->
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>   
     
     

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@ THE SOFTWARE.
           <groupId>classworlds</groupId>
           <artifactId>classworlds</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
      
@@ -105,7 +110,12 @@ THE SOFTWARE.
           <groupId>classworlds</groupId>
           <artifactId>classworlds</artifactId>
         </exclusion>
-      </exclusions>      
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
      
     <dependency>
@@ -127,22 +137,48 @@ THE SOFTWARE.
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-bean</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven31-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven32-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven33-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
@@ -155,6 +191,11 @@ THE SOFTWARE.
           -->
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -172,32 +213,72 @@ THE SOFTWARE.
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-bean</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven31-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven32-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven33-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven35-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven3-interceptor-commons</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-embedder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -216,9 +297,13 @@ THE SOFTWARE.
       <version>3.3.9</version>
     </dependency>      
     <dependency>
+      <!--
+      Maven embedder version has to comply with the minimally supported version of Maven,
+      because it needs to be present on both agent and Maven side
+      -->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>${mavenVersion}</version>
+      <version>3.1.0</version>
     </dependency>   
     
     
@@ -379,7 +464,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.13-20170915.144243-1</version>
+      <version>3.12</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.17</version>
+    <version>2.33</version>
   </parent>
 
   <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->
@@ -44,8 +44,8 @@ THE SOFTWARE.
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <mavenInterceptorsVersion>1.11</mavenInterceptorsVersion>
-    <mavenVersion>3.1.0</mavenVersion>
+    <mavenInterceptorsVersion>1.12-SNAPSHOT</mavenInterceptorsVersion>
+    <mavenVersion>3.5.0</mavenVersion>
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>1.1.0</aetherVersion>
     <sisuInjectVersion>0.3.3</sisuInjectVersion>
@@ -67,26 +67,7 @@ THE SOFTWARE.
     </license>
   </licenses>
   
-  <dependencyManagement>
-    <dependencies>
-      <!-- Newer version of plexus-utils is required for artifact deployment to 
-           work using scpexe wagon (see JENKINS-4861). This may be removed when
-           the effective version of the transitive plexus-utils dependency is 3.0.16+. -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.0.17</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  
   <dependencies>
-    <dependency> <!-- TODO pending https://github.com/jenkinsci/plugin-pom/pull/17 -->
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>javadoc</artifactId>
@@ -223,7 +204,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>${mavenVersion}</version>
+      <version>3.3.9</version>
     </dependency>      
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -309,17 +290,20 @@ THE SOFTWARE.
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.3</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpclient-4-api</artifactId>
+      <version>4.5.3-1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -361,7 +345,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-classworlds</artifactId>
-      <version>2.5.1</version>
+      <version>2.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
@@ -435,7 +419,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -467,11 +451,17 @@ THE SOFTWARE.
       <artifactId>mock-javamail</artifactId>
       <version>1.9</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -566,6 +556,43 @@ THE SOFTWARE.
           </execution>
         </executions>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        
+        <!-- Consider adding to Jenkins plugin parent POM? -->
+        <dependencies>
+          <dependency>
+            <groupId>de.skuzzle.enforcer</groupId>
+            <artifactId>restrict-imports-enforcer-rule</artifactId>
+            <version>0.7.0</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>ban-commons-httpclient-3x</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                  <basePackage>**</basePackage>
+                  <includeTestCode>true</includeTestCode>
+                  <bannedImports>
+                    <bannedImport>org.apache.commons.httpclient.**</bannedImport>
+                  </bannedImports>
+                </restrictImports>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -302,8 +302,8 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpclient-4-api</artifactId>
-      <version>4.5.3-1-SNAPSHOT</version>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>4.5.3-1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,15 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.main.maven</groupId>
       <artifactId>maven35-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!--Jenkins bundles Guava 11.0.1, this library requires 20.0 and makes the plugin to bundle it.
+              The interceptor should not be actually used inside Jenkins, what could possibly go wrong?
+          -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -505,21 +505,6 @@ THE SOFTWARE.
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
-          <configuration>
-            <!-- now defined in parent pom -->
-            <!-- Prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
-            <!-- Must be defined as argLine and not as system property to be used -->
-            <!--argLine>-Djava.awt.headless=true</argLine-->
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -749,23 +749,6 @@ THE SOFTWARE.
               <fail>true</fail>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-      
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        
-        <!-- Consider adding to Jenkins plugin parent POM? -->
-        <dependencies>
-          <dependency>
-            <groupId>de.skuzzle.enforcer</groupId>
-            <artifactId>restrict-imports-enforcer-rule</artifactId>
-            <version>0.7.0</version>
-          </dependency>
-        </dependencies>
-        <executions>
           <execution>
             <id>ban-commons-httpclient-3x</id>
             <phase>process-sources</phase>
@@ -786,8 +769,16 @@ THE SOFTWARE.
             </configuration>
           </execution>
         </executions>
+        
+        <!-- Consider adding to Jenkins plugin parent POM? -->
+        <dependencies>
+          <dependency>
+            <groupId>de.skuzzle.enforcer</groupId>
+            <artifactId>restrict-imports-enforcer-rule</artifactId>
+            <version>0.7.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
-      
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,14 @@ THE SOFTWARE.
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <mavenInterceptorsVersion>1.12-alpha-1</mavenInterceptorsVersion>
+    <!-- Version of Maven Components -->
     <mavenVersion>3.5.0</mavenVersion>
+    <!--
+      Minimal supported version of Maven.
+      It declares version of the core, which should be included into the the server-side.
+      Note that the plugin still bundles agent support for Maven 3.0.5, probably it's not really operational
+    -->
+    <mavenMinimalVersion>3.1.0</mavenMinimalVersion>
     <maven.version>${mavenVersion}</maven.version>
     <aetherVersion>1.1.0</aetherVersion>
     <sisuInjectVersion>0.3.3</sisuInjectVersion>
@@ -137,10 +144,14 @@ THE SOFTWARE.
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-bean</artifactId>
         </exclusion>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -149,10 +160,14 @@ THE SOFTWARE.
       <artifactId>maven31-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -161,10 +176,14 @@ THE SOFTWARE.
       <artifactId>maven32-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -173,10 +192,14 @@ THE SOFTWARE.
       <artifactId>maven33-agent</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -192,10 +215,14 @@ THE SOFTWARE.
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -213,10 +240,19 @@ THE SOFTWARE.
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-bean</artifactId>
         </exclusion>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Interceptor gets it from the Maven Core on the remote side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-aether-provider</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -225,10 +261,19 @@ THE SOFTWARE.
       <artifactId>maven31-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Interceptor gets it from the Maven Core on the remote side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-aether-provider</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -237,10 +282,19 @@ THE SOFTWARE.
       <artifactId>maven32-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Interceptor gets it from the Maven Core on the remote side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-aether-provider</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -249,10 +303,19 @@ THE SOFTWARE.
       <artifactId>maven33-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Interceptor gets it from the Maven Core on the remote side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-aether-provider</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -261,10 +324,14 @@ THE SOFTWARE.
       <artifactId>maven35-interceptor</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -273,28 +340,37 @@ THE SOFTWARE.
       <artifactId>maven3-interceptor-commons</artifactId>
       <version>${mavenInterceptorsVersion}</version>
       <exclusions>
+        <!-- Embedded in Maven, Provided by Maven Embedder Library or Maven Plugin on the Jenkins side -->
         <exclusion>
-          <!-- Embedded in Maven, Provided by Maven Embedder Library on the Jenkins side -->
           <groupId>org.apache.maven</groupId>
           <artifactId>maven-embedder</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Interceptor gets it from the Maven Core on the remote side -->
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-aether-provider</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${mavenMinimalVersion}</version>
     </dependency>  
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${mavenMinimalVersion}</version>
     </dependency>     
     
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>3.3.9</version>
+      <version>${mavenMinimalVersion}</version>
     </dependency>      
     <dependency>
       <!--
@@ -303,7 +379,7 @@ THE SOFTWARE.
       -->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>3.1.0</version>
+      <version>${mavenMinimalVersion}</version>
     </dependency>   
     
     
@@ -455,6 +531,12 @@ THE SOFTWARE.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.0.24</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <version>1.7.1</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>

--- a/src/test/java/hudson/maven/Maven339BuildTest.java
+++ b/src/test/java/hudson/maven/Maven339BuildTest.java
@@ -22,6 +22,7 @@ package hudson.maven;
 
 import hudson.tasks.Maven;
 import hudson.tasks.Maven.MavenInstallation;
+import org.junit.Ignore;
 import org.jvnet.hudson.test.ToolInstallations;
 
 /**
@@ -29,6 +30,7 @@ import org.jvnet.hudson.test.ToolInstallations;
  */
 //TODO: Placeholder for Maven 3.3.9 tests. Inactive, because JTH test tools do not offer such version of Maven
 // Another tool installation approach should be used
+@Ignore
 public class Maven339BuildTest
     extends AbstractMaven3xBuildTest {
 

--- a/src/test/java/hudson/maven/Maven339BuildTest.java
+++ b/src/test/java/hudson/maven/Maven339BuildTest.java
@@ -25,8 +25,10 @@ import hudson.tasks.Maven.MavenInstallation;
 import org.jvnet.hudson.test.ToolInstallations;
 
 /**
- * @author Olivier Lamy
+ * @author Oleg Nenashev
  */
+//TODO: Placeholder for Maven 3.3.9 tests. Inactive, because JTH test tools do not offer such version of Maven
+// Another tool installation approach should be used
 public class Maven339BuildTest
     extends AbstractMaven3xBuildTest {
 

--- a/src/test/java/hudson/maven/Maven339BuildTest.java
+++ b/src/test/java/hudson/maven/Maven339BuildTest.java
@@ -27,15 +27,15 @@ import org.jvnet.hudson.test.ToolInstallations;
 /**
  * @author Olivier Lamy
  */
-public class Maven31xBuildTest
+public class Maven339BuildTest
     extends AbstractMaven3xBuildTest {
 
     @Override
     public MavenInstallation configureMaven3x()
         throws Exception
     {
-        MavenInstallation mvn = ToolInstallations.configureDefaultMaven("apache-maven-3.1.0", MavenInstallation.MAVEN_30);
-        MavenInstallation m3 = new MavenInstallation("apache-maven-3.1.0", mvn.getHome(), j.NO_PROPERTIES);
+        MavenInstallation mvn = ToolInstallations.configureDefaultMaven("apache-maven-3.3.9", MavenInstallation.MAVEN_30);
+        MavenInstallation m3 = new MavenInstallation("apache-maven-3.3.9", mvn.getHome(), j.NO_PROPERTIES);
         j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m3);
         return m3;
     }

--- a/src/test/java/hudson/maven/Maven35xBuildTest.java
+++ b/src/test/java/hudson/maven/Maven35xBuildTest.java
@@ -27,15 +27,15 @@ import org.jvnet.hudson.test.ToolInstallations;
 /**
  * @author Olivier Lamy
  */
-public class Maven31xBuildTest
+public class Maven35xBuildTest
     extends AbstractMaven3xBuildTest {
 
     @Override
     public MavenInstallation configureMaven3x()
         throws Exception
     {
-        MavenInstallation mvn = ToolInstallations.configureDefaultMaven("apache-maven-3.1.0", MavenInstallation.MAVEN_30);
-        MavenInstallation m3 = new MavenInstallation("apache-maven-3.1.0", mvn.getHome(), j.NO_PROPERTIES);
+        MavenInstallation mvn = ToolInstallations.configureDefaultMaven("apache-maven-3.5.0", MavenInstallation.MAVEN_30);
+        MavenInstallation m3 = new MavenInstallation("apache-maven-3.5.0", mvn.getHome(), j.NO_PROPERTIES);
         j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m3);
         return m3;
     }

--- a/src/test/java/hudson/maven/Maven35xBuildTest.java
+++ b/src/test/java/hudson/maven/Maven35xBuildTest.java
@@ -22,11 +22,15 @@ package hudson.maven;
 
 import hudson.tasks.Maven;
 import hudson.tasks.Maven.MavenInstallation;
+import org.junit.Ignore;
 import org.jvnet.hudson.test.ToolInstallations;
 
 /**
- * @author Olivier Lamy
+ * @author Oleg Nenashev
  */
+//TODO: Placeholder for Maven 3.5 tests. Inactive, because JTH test tools do not offer such version of Maven
+// Another tool installation approach should be used
+@Ignore
 public class Maven35xBuildTest
     extends AbstractMaven3xBuildTest {
 


### PR DESCRIPTION
- [x] [JENKINS-46053](https://issues.jenkins-ci.org/browse/JENKINS-46053) - Maven Interceptors do not bundle Commons HttpClient 3.x anymore
  * Upstream PR: https://github.com/jenkinsci/maven-interceptors/pull/13
- [x]  [JENKINS-46210](https://issues.jenkins-ci.org/browse/JENKINS-46210) - Apache HTTPComponents Client 4.x now comes from the [new API Plugin](https://wiki.jenkins.io/display/JENKINS/Apache+HttpComponents+Client+4.x+API+Plugin)
- [x] [JENKINS-45271](https://issues.jenkins-ci.org/browse/JENKINS-45271) - Update Parent POM and cleanup Upper Bound dependencies
  * Upstream PR: https://github.com/jenkinsci/maven-interceptors/pull/12
  * Upstream PR: https://github.com/jenkinsci/pom/pull/14
- [x] [JENKINS-46148](https://issues.jenkins-ci.org/browse/JENKINS-46148) - Remove old APIs which were used in Maven Core 3.1.0. It was required for upper bounds
- [x] - Update Maven Embedder to version with embedded 3.5.0
  * https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/14
- [x] - Use HttpComponents Client 4.x and JSch from Jenkins plugins

Downstream PRs: 
* https://github.com/jenkinsci/analysis-pom-plugin/pull/7

@reviewbybees @jtnord @rysteboe @jglick @aheritier @olamy (seems there is a nice party in the CC list)