### PR TITLE
Include dependency management imports as dependencies

### DIFF
--- a/src/main/java/hudson/maven/MavenUtil.java
+++ b/src/main/java/hudson/maven/MavenUtil.java
@@ -331,6 +331,35 @@ public class MavenUtil {
         return new ComparableVersion(mavenVersion).compareTo( new ComparableVersion ("3.1.0") ) >= 0;
     }
 
+    public static String resolveVersion(String version, MavenProject project) {
+        final int tokenIdx = version.indexOf("${");
+        if (tokenIdx == -1) {
+            LOGGER.finest("Returning version " + version + " unchanged");
+            return version;
+        }
+        final Properties props = project.getProperties();
+        if (props != null) {
+            if (tokenIdx == 0) {
+                if (version.indexOf("}") == version.length() - 1) {
+                    final String propName = version.substring(2, version.length() - 1);
+                    if (props.containsKey(propName)) {
+                        final String value = props.getProperty(propName);
+                        LOGGER.finest("Found property value " + value + " for version " + version);
+                        return value;
+                    } else {
+                        LOGGER.finest("No property found for " + propName);
+                    }
+                } else {
+                    LOGGER.finest("Matching curly brace not at end of version " + version);
+                }
+            }
+        } else {
+            LOGGER.finest("No properties to resolve version " + version);
+        }
+        LOGGER.fine("Could not resolve version " + version + ", returning null instead");
+        return null;
+    }
+
     public enum MavenVersion {
         MAVEN_2,MAVEN_3_0_X,MAVEN_3_1,MAVEN_3_2,MAVEN_3_3, MAVEN_3_5
     }

--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -26,7 +26,9 @@ package hudson.maven;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.CiManagement;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Extension;
+import org.apache.maven.model.Model;
 import org.apache.maven.model.Notifier;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
@@ -130,6 +132,19 @@ final class PomInfo implements Serializable {
 
         for (Dependency dep : project.getDependencies())
             dependencies.add(new ModuleDependency(dep));
+
+        // Imported dependencyManagement are also dependencies
+        Model originalModel = project.getOriginalModel();
+        if (originalModel != null) {
+            DependencyManagement originalDependencyManagement = originalModel.getDependencyManagement();
+            if (originalDependencyManagement != null) {
+                for (Dependency dep : originalDependencyManagement.getDependencies()) {
+                    if (dep.getScope() != null && dep.getScope().equals("import")) {
+                        dependencies.add(new ModuleDependency((dep)));
+                    }
+                }
+            }
+        }
 
         MavenProject parentProject = project.getParent();
         if(parentProject!=null)

--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -140,7 +140,7 @@ final class PomInfo implements Serializable {
             if (originalDependencyManagement != null) {
                 for (Dependency dep : originalDependencyManagement.getDependencies()) {
                     if (dep.getScope() != null && dep.getScope().equals("import")) {
-                        dependencies.add(new ModuleDependency((dep)));
+                        dependencies.add(new ModuleDependency(dep));
                     }
                 }
             }

--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -35,10 +35,11 @@ import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.project.MavenProject;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.ArrayList;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 /**
@@ -120,6 +121,8 @@ final class PomInfo implements Serializable {
      */
     public final String packaging;
 
+    private static final Logger LOGGER = Logger.getLogger(PomInfo.class.getName());
+
     public PomInfo(MavenProject project, PomInfo parent, String relPath) {
         this.name = new ModuleName(project);
         this.version = project.getVersion();
@@ -133,14 +136,20 @@ final class PomInfo implements Serializable {
         for (Dependency dep : project.getDependencies())
             dependencies.add(new ModuleDependency(dep));
 
+
         // Imported dependencyManagement are also dependencies
         Model originalModel = project.getOriginalModel();
         if (originalModel != null) {
             DependencyManagement originalDependencyManagement = originalModel.getDependencyManagement();
             if (originalDependencyManagement != null) {
                 for (Dependency dep : originalDependencyManagement.getDependencies()) {
+                    if (dep == null) {
+                        continue;
+                    }
                     if (dep.getScope() != null && dep.getScope().equals("import")) {
-                        dependencies.add(new ModuleDependency(dep));
+                        final Dependency depClone = dep.clone();
+                        depClone.setVersion(MavenUtil.resolveVersion(depClone.getVersion(), project));
+                        dependencies.add(new ModuleDependency(depClone));
                     }
                 }
             }
@@ -181,7 +190,7 @@ final class PomInfo implements Serializable {
         this.artifactId = project.getArtifactId();
         this.packaging = project.getPackaging();
     }
-    
+
     /**
      * Creates {@link ModuleDependency} that represents this {@link PomInfo}.
      */

--- a/src/test/java/hudson/maven/MavenUtilTest.java
+++ b/src/test/java/hudson/maven/MavenUtilTest.java
@@ -22,7 +22,9 @@ package hudson.maven;
  */
 
 
+import org.apache.maven.project.MavenProject;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -63,5 +65,39 @@ public class MavenUtilTest
     @Test
     public void eventSpy31x(){
         Assert.assertTrue( MavenUtil.supportEventSpy( "3.1.0" ) );
+    }
+
+    private MavenProject project;
+
+    @Before
+    public void setUp() {
+        project = new MavenProject();
+        project.setGroupId("test");
+        project.setArtifactId("testmodule");
+        project.setVersion("2.0-SNAPSHOT");
+        project.setPackaging("jar");
+    }
+
+    @Test
+    public void resolveVersionPlain() {
+        Assert.assertTrue("1.2.3".equals(MavenUtil.resolveVersion("1.2.3", project)));
+    }
+
+    @Test
+    public void resolveVersionComplex() {
+        Assert.assertNull(MavenUtil.resolveVersion("1.${abc}.3", project));
+        Assert.assertNull(MavenUtil.resolveVersion("1.${abc}", project));
+        Assert.assertNull(MavenUtil.resolveVersion("${abc}.3", project));
+    }
+
+    @Test
+    public void resolveVersionMissingProperty() {
+        Assert.assertNull(MavenUtil.resolveVersion("${abc}", project));
+    }
+
+    @Test
+    public void resolveVersionProperty() {
+        project.getProperties().setProperty("abc", "1.2.3");
+        Assert.assertTrue("1.2.3".equals(MavenUtil.resolveVersion("${abc}", project)));
     }
 }

--- a/src/test/java/hudson/maven/PomInfoTest.java
+++ b/src/test/java/hudson/maven/PomInfoTest.java
@@ -1,0 +1,4 @@
+package hudson.maven;
+
+public class PomInfoTest {
+}

--- a/src/test/java/hudson/maven/PomInfoTest.java
+++ b/src/test/java/hudson/maven/PomInfoTest.java
@@ -5,20 +5,25 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class PomInfoTest {
     private MavenProject project;
 
-    @Test
-    public void testImportedDependencyManagementIncludedInDependencies() {
-        this.project = new MavenProject();
+    @Before
+    public void setUp() {
+        project = new MavenProject();
         project.setGroupId("test");
         project.setArtifactId("testmodule");
         project.setVersion("2.0-SNAPSHOT");
         project.setPackaging("jar");
         project.setOriginalModel(new Model());
         project.getOriginalModel().setDependencyManagement(new DependencyManagement());
+    }
+
+    @Test
+    public void testImportedDependencyManagementIncludedInDependencies() {
         Dependency depImport = new Dependency();
         depImport.setGroupId("importedGroup");
         depImport.setArtifactId("importedArtifact");
@@ -29,5 +34,18 @@ public class PomInfoTest {
 
         final PomInfo pomInfo = new PomInfo(project, null, "relPath");
         Assert.assertTrue(pomInfo.dependencies.contains(modDepImport));
+    }
+
+    @Test
+    public void testRegularDependencyManagementNotIncludedInDependencies() {
+        Dependency depImport = new Dependency();
+        depImport.setGroupId("group");
+        depImport.setArtifactId("artifact");
+        depImport.setVersion("1.0-SNAPSHOT");
+        project.getOriginalModel().getDependencyManagement().addDependency(depImport);
+        ModuleDependency modDepImport = new ModuleDependency(depImport);
+
+        final PomInfo pomInfo = new PomInfo(project, null, "relPath");
+        Assert.assertFalse(pomInfo.dependencies.contains(modDepImport));
     }
 }

--- a/src/test/java/hudson/maven/PomInfoTest.java
+++ b/src/test/java/hudson/maven/PomInfoTest.java
@@ -1,4 +1,33 @@
 package hudson.maven;
 
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Test;
+
 public class PomInfoTest {
+    private MavenProject project;
+
+    @Test
+    public void testImportedDependencyManagementIncludedInDependencies() {
+        this.project = new MavenProject();
+        project.setGroupId("test");
+        project.setArtifactId("testmodule");
+        project.setVersion("2.0-SNAPSHOT");
+        project.setPackaging("jar");
+        project.setOriginalModel(new Model());
+        project.getOriginalModel().setDependencyManagement(new DependencyManagement());
+        Dependency depImport = new Dependency();
+        depImport.setGroupId("importedGroup");
+        depImport.setArtifactId("importedArtifact");
+        depImport.setVersion("1.0-SNAPSHOT");
+        depImport.setScope("import");
+        project.getOriginalModel().getDependencyManagement().addDependency(depImport);
+        ModuleDependency modDepImport = new ModuleDependency(depImport);
+
+        final PomInfo pomInfo = new PomInfo(project, null, "relPath");
+        Assert.assertTrue(pomInfo.dependencies.contains(modDepImport));
+    }
 }


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-15883

This change looks through the original dependencyManagement entries and adds any entry with a scope of import to the dependencies of the project.

Thanks to the [smartics NoSnapshotsInDependencyManagementRule](https://github.com/smartics/smartics-enforcer-rules/blob/master/src/main/java/de/smartics/maven/enforcer/rule/NoSnapshotsInDependencyManagementRule.java#L97) for helping me find the right calls.