### PR TITLE
[JENKINS-47233] - Restore the fix of JENKINS-42549

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.12</version>
+      <version>3.12.1</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>


### PR DESCRIPTION
The fix has been reverted in 3.0.0-rc1 by https://github.com/jenkinsci/maven-plugin/pull/102.
It was just a mistake I made when patching the dependencies, but unfortunately nobody noticed it during the code review.

https://issues.jenkins-ci.org/browse/JENKINS-47233

@reviewbybees