### PR TITLE
Make createComputerLauncher() in tests compatible with Jenkins

### DIFF
--- a/src/test/java/hudson/maven/AbstractMavenTestCase.java
+++ b/src/test/java/hudson/maven/AbstractMavenTestCase.java
@@ -1,12 +1,15 @@
 package hudson.maven;
 
 import hudson.EnvVars;
+import hudson.model.Slave;
 import hudson.slaves.CommandLauncher;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.net.URL;
 
 /**
  * Customisation of the deprecated HudsonTestCase to fix the lost of window focus when tests are launched on MacOS.
@@ -37,9 +40,15 @@ public abstract class AbstractMavenTestCase extends HudsonTestCase {
     @Override
     public CommandLauncher createComputerLauncher(EnvVars env) throws URISyntaxException, MalformedURLException {
         int sz = this.jenkins.getNodes().size();
+        final URL slaveJarURL;
+        try {
+            slaveJarURL = this.jenkins.getJnlpJars("slave.jar").getURL();
+        } catch (IOException ex) {
+            throw new AssertionError("Cannot retrieve slave.jar for the test", ex);
+        }
         return new CommandLauncher(String.format("\"%s/bin/java\" %s %s -jar \"%s\"",
                 new Object[]{System.getProperty("java.home"), JAVA_HEADLESS_OPT, SLAVE_DEBUG_PORT > 0 ?
                         " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=" + (SLAVE_DEBUG_PORT + sz) : "",
-                        (new File(this.jenkins.getJnlpJars("slave.jar").getURL().toURI())).getAbsolutePath()}), env);
+                        (new File(slaveJarURL.toURI())).getAbsolutePath()}), env);
     }
 }


### PR DESCRIPTION
Fixes source incompatibility after https://github.com/jenkinsci/jenkins/pull/2633 in the core.

It does not solve all issues. MockHelper class is still incompatible, because the `DependencyGraph#getAllProjects()` package-scope method has been removed by @stephenc in 2.37 (https://github.com/jenkinsci/jenkins/commit/16254cb8ba1e3700869f79fb74ef1c79b34d0afc). Yes, package-scope methods can be used in detached plugins :(

@reviewbybees @jglick @aheritier 