### PR TITLE
Update Lib Maven Embedder to 3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,9 +544,10 @@ THE SOFTWARE.
       <version>1.2</version>
     </dependency>
     <dependency>
+      <!-- TODO: fix exclusion once updated to the 3.5.0 baseline -->
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.12.1</version>
+      <version>3.13</version>
       <exclusions>
         <exclusion><!-- we'll add our own patched version. see https://issues.jenkins-ci.org/browse/JENKINS-1680 -->
           <groupId>jtidy</groupId>


### PR DESCRIPTION
Mainly integrates https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/15 from @jglick. It addresses some bits for for JEP-200/JENKINS-47736 though generally it is not mandatory.

* Changelog: https://github.com/jenkinsci/lib-jenkins-maven-embedder/blob/maven-3.1.0/CHANGELOG.md#313
* Full diff: https://github.com/jenkinsci/lib-jenkins-maven-embedder/compare/lib-jenkins-maven-embedder-3.12.1...lib-jenkins-maven-embedder-3.13

@reviewbybees @aheritier @olamy 