### PR TITLE
[JENKINS-49262] Apply log filters (e.g. Timestamper, AnsiColor) to module builds

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -58,6 +58,7 @@ import jenkins.maven3.agent.Maven31Main;
 import jenkins.maven3.agent.Maven32Main;
 import jenkins.maven3.agent.Maven33Main;
 
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ReactorManager;
@@ -75,8 +76,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -590,10 +589,10 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
         private final MavenModuleSetBuild parentBuild;
         private boolean blockBuildEvents;
 
-        ProxyImpl2(MavenModuleSetBuild parentBuild,SplittableBuildListener listener) throws FileNotFoundException {
+        ProxyImpl2(MavenModuleSetBuild parentBuild,SplittableBuildListener listener,OutputStream log) {
             this.parentBuild = parentBuild;
             this.listener = listener;
-            log = new FileOutputStream(getLogFile()); // no buffering so that AJAX clients can see the log live
+            this.log = log;
         }
 
         public void start() {
@@ -896,7 +895,7 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                 ProxyImpl proxy;
                 if (mavenBuildInformation.isMaven3OrLater())
                 {
-                    ProxyImpl2 proxy2 = new ProxyImpl2(mms.getLastCompletedBuild(), slistener);
+                    ProxyImpl2 proxy2 = new ProxyImpl2(mms.getLastCompletedBuild(), slistener, new NullOutputStream());
                     proxy2.setBlockBuildEvents(true);
                     proxy = proxy2;
                     builder = new Maven3Builder(createRequest(proxy2,

--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -589,7 +589,7 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
         private final MavenModuleSetBuild parentBuild;
         private boolean blockBuildEvents;
 
-        ProxyImpl2(MavenModuleSetBuild parentBuild,SplittableBuildListener listener,OutputStream log) {
+        ProxyImpl2(MavenModuleSetBuild parentBuild, SplittableBuildListener listener, OutputStream log) {
             this.parentBuild = parentBuild;
             this.listener = listener;
             this.log = log;

--- a/src/main/java/hudson/maven/MavenModule.java
+++ b/src/main/java/hudson/maven/MavenModule.java
@@ -32,6 +32,7 @@ import hudson.Util;
 import hudson.maven.reporters.MavenMailer;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
+import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.DependencyGraph;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
@@ -43,6 +44,7 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Resource;
 import hudson.model.Saveable;
+import hudson.tasks.BuildWrapper;
 import hudson.tasks.LogRotator;
 import hudson.tasks.Maven.MavenInstallation;
 import hudson.tasks.Publisher;
@@ -77,7 +79,7 @@ import java.util.logging.Logger;
  * 
  * @author Kohsuke Kawaguchi
  */
-public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> implements Saveable {
+public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> implements Saveable, BuildableItemWithBuildWrappers {
     private DescribableList<MavenReporter,Descriptor<MavenReporter>> reporters =
         new DescribableList<MavenReporter,Descriptor<MavenReporter>>(this);
 
@@ -792,6 +794,17 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
      */
     public Set<ModuleDependency> getDependencies() {
         return new HashSet<ModuleDependency>( dependencies);
+    }
+
+    @Override
+    public AbstractProject<?, ?> asProject() {
+        return this;
+    }
+
+    @Override
+    public DescribableList<BuildWrapper, Descriptor<BuildWrapper>> getBuildWrappersList() {
+        // inherit build wrappers configured on the parent project
+        return getParent().getBuildWrappersList();
     }
 
     /**

--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -63,8 +63,10 @@ import hudson.util.IOUtils;
 import hudson.util.StreamTaskListener;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.net.URL;
@@ -730,7 +732,8 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                             }
 
                             mb.setWorkspace(getModuleRoot().child(m.getRelativePath()));
-                            proxies.put(moduleName, mb.new ProxyImpl2(MavenModuleSetBuild.this,slistener));
+                            OutputStream moduleLogger = new FileOutputStream(mb.getLogFile()); // no buffering so that AJAX clients can see the log live
+                            proxies.put(moduleName, mb.new ProxyImpl2(MavenModuleSetBuild.this,slistener,moduleLogger));
                         }
 
                         // run the complete build here

--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -733,7 +733,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                             }
 
                             mb.setWorkspace(getModuleRoot().child(m.getRelativePath()));
-                            proxies.put(moduleName, mb.new ProxyImpl2(MavenModuleSetBuild.this,slistener,createModuleLogger(mb)));
+                            proxies.put(moduleName, mb.new ProxyImpl2(MavenModuleSetBuild.this, slistener, createModuleLogger(mb)));
                         }
 
                         // run the complete build here


### PR DESCRIPTION
[JENKINS-49262](https://issues.jenkins-ci.org/browse/JENKINS-49262)

Apply log filters to each module build, not just the top-level module set build.

Scenarios tested with Timestamper 1.8.9:
* parallel build, Maven 3
* aggregate build, Maven 3
* parallel build, Maven 2
* aggregate build, Maven 2