### PR TITLE
[JENKINS-50251] JEP-200 failure to serialize Notifier

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin platforms: ['linux'], jenkinsVersions: [null, '2.103']
+buildPlugin platforms: ['linux'], jenkinsVersions: [null, '2.107.1']

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.6</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/hudson/maven/MavenModule.java
+++ b/src/main/java/hudson/maven/MavenModule.java
@@ -50,7 +50,6 @@ import hudson.util.AlternativeUiTextProvider;
 import hudson.util.DescribableList;
 import jenkins.model.Jenkins;
 
-import org.apache.maven.model.Notifier;
 import org.apache.maven.project.MavenProject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -212,7 +211,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         
         MavenMailer projectMailer = getParent().getReporters() == null? null: getParent().getReporters().get(MavenMailer.class);
         if (projectMailer != null) {
-        	Notifier notifier = getCiManagementNotifier(pom);
+        	NotifierInfo notifier = getCiManagementNotifier(pom);
 	        if (notifier != null) {
 	            MavenMailer mailer;
 	            
@@ -223,9 +222,9 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
 	        	}
 	            
 	        	mailer.perModuleEmail = projectMailer.perModuleEmail;
-                mailer.dontNotifyEveryUnstableBuild = !notifier.isSendOnFailure();
+                mailer.dontNotifyEveryUnstableBuild = !notifier.sendOnFailure;
                 
-                String recipients = notifier.getConfiguration().getProperty("recipients");
+                String recipients = notifier.recipients;
                 
                 mailer.recipients = projectMailer.recipients;
                 mailer.mavenRecipients = recipients;
@@ -251,8 +250,8 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
 		return mavenMailer;
 	}
 
-	private Notifier getCiManagementNotifier(PomInfo pom) {
-		Notifier notifier = null;
+	private NotifierInfo getCiManagementNotifier(PomInfo pom) {
+		NotifierInfo notifier = null;
 		
 		if (pom.mailNotifier != null) {
 			notifier = pom.mailNotifier;

--- a/src/main/java/hudson/maven/NotifierInfo.java
+++ b/src/main/java/hudson/maven/NotifierInfo.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.maven;
+
+import java.io.Serializable;
+import org.apache.maven.model.Notifier;
+
+/**
+ * Those components of {@link Notifier} we pay attention to.
+ */
+final class NotifierInfo implements Serializable {
+
+    public final boolean sendOnFailure;
+    public final String recipients;
+
+    NotifierInfo(Notifier notifier) {
+        sendOnFailure = notifier.isSendOnFailure();
+        recipients = notifier.getConfiguration().getProperty("recipients");
+    }
+
+}

--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -112,7 +113,7 @@ final class PomInfo implements Serializable {
      */    
     private final String artifactId;
 
-    public final Notifier mailNotifier;
+    public final @CheckForNull NotifierInfo mailNotifier;
     
     /**
      * Packaging type taken from the POM.
@@ -182,7 +183,7 @@ final class PomInfo implements Serializable {
                     break;
                 }
             }
-            this.mailNotifier = mailNotifier;
+            this.mailNotifier = new NotifierInfo(mailNotifier);
         } else
             this.mailNotifier = null;
         

--- a/src/test/java/hudson/maven/reporters/MavenMailerTest.java
+++ b/src/test/java/hudson/maven/reporters/MavenMailerTest.java
@@ -48,6 +48,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.mock_javamail.Mailbox;
@@ -129,7 +130,7 @@ public class MavenMailerTest {
 	 * @throws Exception
 	 */
     @Test
-    @Bug(1201)
+    @Issue({"JENKINS-1201", "JENKINS-50251"})
     public void testCiManagementNotificationRoot() throws Exception {
     	JenkinsLocationConfiguration.get().setAdminAddress(EMAIL_ADMIN);
         Mailbox yourInbox = Mailbox.get(new InternetAddress(EMAIL_SOME));
@@ -139,6 +140,7 @@ public class MavenMailerTest {
 
         ToolInstallations.configureDefaultMaven();
         MavenModuleSet mms = j.jenkins.createProject(MavenModuleSet.class, "p");
+        mms.setAssignedNode(j.createSlave());
         mms.setGoals("test");
         mms.setScm(new ExtractResourceSCM(getClass().getResource("/hudson/maven/JENKINS-1201-parent-defined.zip")));
         


### PR DESCRIPTION
[JENKINS-50251](https://issues.jenkins-ci.org/browse/JENKINS-50251): used when `<ciManagement>` specifies email configuration. Follows up #112 & https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/15.

@reviewbybees