### PR TITLE
[JENKINS-50251] the fix introduces a new NullPointerException if ciM…

### DIFF
--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -183,7 +183,8 @@ final class PomInfo implements Serializable {
                     break;
                 }
             }
-            this.mailNotifier = new NotifierInfo(mailNotifier);
+            if (mailNotifier!=null)
+                this.mailNotifier = new NotifierInfo(mailNotifier);
         } else
             this.mailNotifier = null;
         


### PR DESCRIPTION
…anagement does not specify a system other than hudson.

The consuming classes do check for a null PomInfo#mailNotifier, but in this case the NotifierInfo instance is created, but it refers to a null Notifier.
This fix only creates the wrapping NotifierInfo when a Notifier was found.

[JENKINS-50251](https://issues.jenkins-ci.org/browse/JENKINS-50251) amending #115