### PR TITLE
pass maven.multiModuleProjectDirectory option to maven argument builder

### DIFF
--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -881,6 +881,7 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                 process = MavenBuild.mavenProcessCache.get( launcher.getChannel(), slistener, factory);
 
                 ArgumentListBuilder margs = new ArgumentListBuilder("-N","-B");
+                margs.add("-Dmaven.multiModuleProjectDirectory="+getModuleRoot().getRemote());
                 FilePath localRepo = mms.getLocalRepository().locate(MavenBuild.this);
                 if(localRepo!=null)
                     // the workspace must be on this node, so getRemote() is safe.


### PR DESCRIPTION
as it done by regular mvn command.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>