### PR TITLE
Do not bundle commons-io in this plugin's HPI file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,11 @@ THE SOFTWARE.
           <artifactId>commons-cli</artifactId>
         </exclusion>
         <exclusion>
+          <!-- Excluded to pull in the version from Jenkins core -->
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>


### PR DESCRIPTION
commons-io is a dependency of Jenkins core, so we do not want to package a copy of it here, since it will go unused.

<summary>
Here is the table of contents of this plugin's HPI file before this PR: 
<details>

```
$ jar -tf target/maven-plugin.hpi
META-INF/
META-INF/MANIFEST.MF
images/
images/16x16/
images/32x32/
images/24x24/
images/48x48/
WEB-INF/
WEB-INF/lib/
( ... various HTML files ... )
( ... various PNG files ... )
WEB-INF/licenses.xml
WEB-INF/lib/wagon-ssh-3.3.2.jar
WEB-INF/lib/wagon-ftp-3.3.2.jar
WEB-INF/lib/wagon-webdav-jackrabbit-3.3.2.jar
WEB-INF/lib/jsch.agentproxy.connector-factory-0.0.9.jar
WEB-INF/lib/jsch.agentproxy.jsch-0.0.9.jar
WEB-INF/lib/wagon-http-3.3.2.jar
WEB-INF/lib/maven-repository-metadata-3.5.4.jar
WEB-INF/lib/jsr305-1.3.9.jar
WEB-INF/lib/maven-resolver-transport-wagon-1.1.1.jar
WEB-INF/lib/wagon-ssh-external-3.3.2.jar
WEB-INF/lib/jsch.agentproxy.pageant-0.0.9.jar
WEB-INF/lib/maven-resolver-provider-3.5.4.jar
WEB-INF/lib/maven-reporting-api-3.0.jar
WEB-INF/lib/plexus-utils-3.1.0.jar
WEB-INF/lib/maven3-interceptor-1.13.jar
WEB-INF/lib/plexus-interpolation-1.24.jar
WEB-INF/lib/maven-artifact-3.5.4.jar
WEB-INF/lib/plexus-cipher-1.7.jar
WEB-INF/lib/maven33-interceptor-1.13.jar
WEB-INF/lib/cdi-api-1.0.jar
WEB-INF/lib/jsch.agentproxy.usocket-jna-0.0.9.jar
WEB-INF/lib/maven-resolver-spi-1.1.1.jar
WEB-INF/lib/maven-compat-3.5.4.jar
WEB-INF/lib/maven32-interceptor-1.13.jar
WEB-INF/lib/maven-plugin-api-3.5.4.jar
WEB-INF/lib/plexus-sec-dispatcher-1.4.jar
WEB-INF/lib/maven-resolver-util-1.1.1.jar
WEB-INF/lib/maven3-interceptor-commons-1.13.jar
WEB-INF/lib/plexus-component-annotations-1.7.1.jar
WEB-INF/lib/maven-settings-builder-3.5.4.jar
WEB-INF/lib/plexus-interactivity-api-1.0-alpha-6.jar
WEB-INF/lib/commons-cli-1.4.jar
WEB-INF/lib/jsoup-1.11.3.jar
WEB-INF/lib/plexus-classworlds-2.6.0.jar
WEB-INF/lib/maven33-agent-1.13.jar
WEB-INF/lib/wagon-http-shared-3.3.2.jar
WEB-INF/lib/maven-core-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.core-0.0.9.jar
WEB-INF/lib/maven-resolver-impl-1.1.1.jar
WEB-INF/lib/maven2.1-interceptor-1.2.jar
WEB-INF/lib/jna-platform-4.1.0.jar
WEB-INF/lib/wagon-ssh-common-3.3.2.jar
WEB-INF/lib/commons-io-2.6.jar
WEB-INF/lib/lib-jenkins-maven-embedder-3.14.jar
WEB-INF/lib/maven31-interceptor-1.13.jar
WEB-INF/lib/maven35-agent-1.13.jar
WEB-INF/lib/annotations-3.0.1.jar
WEB-INF/lib/org.eclipse.sisu.inject-0.3.3.jar
WEB-INF/lib/maven-plugin.jar
WEB-INF/lib/maven32-agent-1.13.jar
WEB-INF/lib/maven-builder-support-3.5.4.jar
WEB-INF/lib/wagon-file-3.3.2.jar
WEB-INF/lib/jackrabbit-webdav-2.14.4.jar
WEB-INF/lib/maven-model-3.5.4.jar
WEB-INF/lib/maven35-interceptor-1.13.jar
WEB-INF/lib/maven-settings-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.usocket-nc-0.0.9.jar
WEB-INF/lib/maven-interceptor-1.13.jar
WEB-INF/lib/maven-resolver-api-1.1.1.jar
WEB-INF/lib/maven-resolver-connector-basic-1.1.1.jar
WEB-INF/lib/maven-agent-1.13.jar
WEB-INF/lib/doxia-sink-api-1.0.jar
WEB-INF/lib/maven-shared-utils-3.2.1.jar
WEB-INF/lib/commons-net-3.6.jar
WEB-INF/lib/commons-lang3-3.7.jar
WEB-INF/lib/org.eclipse.sisu.plexus-0.3.3.jar
WEB-INF/lib/maven-model-builder-3.5.4.jar
WEB-INF/lib/lib-jenkins-maven-artifact-manager-1.2.jar
WEB-INF/lib/maven3-agent-1.13.jar
WEB-INF/lib/javax.inject-1.jar
WEB-INF/lib/maven-embedder-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.sshagent-0.0.9.jar
WEB-INF/lib/jsr250-api-1.0.jar
WEB-INF/lib/wagon-provider-api-3.3.2.jar
WEB-INF/lib/maven31-agent-1.13.jar
META-INF/maven/
META-INF/maven/org.jenkins-ci.main/
META-INF/maven/org.jenkins-ci.main/maven-plugin/
META-INF/maven/org.jenkins-ci.main/maven-plugin/pom.xml
META-INF/maven/org.jenkins-ci.main/maven-plugin/pom.properties
```
</details>
</summary>

<summary>
And here is the table of contents of this plugin's HPI file after this PR (the only difference is that commons-io-2.6.jar is no longer present): 
<details>

```
$ jar -tf target/maven-plugin.hpi 
META-INF/
META-INF/MANIFEST.MF
images/
images/16x16/
images/32x32/
images/24x24/
images/48x48/
WEB-INF/
WEB-INF/lib/
( ... various HTML files ... )
( ... various PNG files ... )
WEB-INF/licenses.xml
WEB-INF/lib/wagon-ssh-3.3.2.jar
WEB-INF/lib/wagon-ftp-3.3.2.jar
WEB-INF/lib/wagon-webdav-jackrabbit-3.3.2.jar
WEB-INF/lib/jsch.agentproxy.connector-factory-0.0.9.jar
WEB-INF/lib/jsch.agentproxy.jsch-0.0.9.jar
WEB-INF/lib/wagon-http-3.3.2.jar
WEB-INF/lib/maven-repository-metadata-3.5.4.jar
WEB-INF/lib/jsr305-1.3.9.jar
WEB-INF/lib/maven-resolver-transport-wagon-1.1.1.jar
WEB-INF/lib/wagon-ssh-external-3.3.2.jar
WEB-INF/lib/jsch.agentproxy.pageant-0.0.9.jar
WEB-INF/lib/maven-resolver-provider-3.5.4.jar
WEB-INF/lib/maven-reporting-api-3.0.jar
WEB-INF/lib/plexus-utils-3.1.0.jar
WEB-INF/lib/maven3-interceptor-1.13.jar
WEB-INF/lib/plexus-interpolation-1.24.jar
WEB-INF/lib/maven-artifact-3.5.4.jar
WEB-INF/lib/plexus-cipher-1.7.jar
WEB-INF/lib/maven33-interceptor-1.13.jar
WEB-INF/lib/cdi-api-1.0.jar
WEB-INF/lib/jsch.agentproxy.usocket-jna-0.0.9.jar
WEB-INF/lib/maven-resolver-spi-1.1.1.jar
WEB-INF/lib/maven-compat-3.5.4.jar
WEB-INF/lib/maven32-interceptor-1.13.jar
WEB-INF/lib/maven-plugin-api-3.5.4.jar
WEB-INF/lib/plexus-sec-dispatcher-1.4.jar
WEB-INF/lib/maven-resolver-util-1.1.1.jar
WEB-INF/lib/maven3-interceptor-commons-1.13.jar
WEB-INF/lib/plexus-component-annotations-1.7.1.jar
WEB-INF/lib/maven-settings-builder-3.5.4.jar
WEB-INF/lib/plexus-interactivity-api-1.0-alpha-6.jar
WEB-INF/lib/commons-cli-1.4.jar
WEB-INF/lib/jsoup-1.11.3.jar
WEB-INF/lib/plexus-classworlds-2.6.0.jar
WEB-INF/lib/maven33-agent-1.13.jar
WEB-INF/lib/wagon-http-shared-3.3.2.jar
WEB-INF/lib/maven-core-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.core-0.0.9.jar
WEB-INF/lib/maven-resolver-impl-1.1.1.jar
WEB-INF/lib/maven2.1-interceptor-1.2.jar
WEB-INF/lib/jna-platform-4.1.0.jar
WEB-INF/lib/wagon-ssh-common-3.3.2.jar
WEB-INF/lib/lib-jenkins-maven-embedder-3.14.jar
WEB-INF/lib/maven31-interceptor-1.13.jar
WEB-INF/lib/maven35-agent-1.13.jar
WEB-INF/lib/annotations-3.0.1.jar
WEB-INF/lib/org.eclipse.sisu.inject-0.3.3.jar
WEB-INF/lib/maven-plugin.jar
WEB-INF/lib/maven32-agent-1.13.jar
WEB-INF/lib/maven-builder-support-3.5.4.jar
WEB-INF/lib/wagon-file-3.3.2.jar
WEB-INF/lib/jackrabbit-webdav-2.14.4.jar
WEB-INF/lib/maven-model-3.5.4.jar
WEB-INF/lib/maven35-interceptor-1.13.jar
WEB-INF/lib/maven-settings-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.usocket-nc-0.0.9.jar
WEB-INF/lib/maven-interceptor-1.13.jar
WEB-INF/lib/maven-resolver-api-1.1.1.jar
WEB-INF/lib/maven-resolver-connector-basic-1.1.1.jar
WEB-INF/lib/maven-agent-1.13.jar
WEB-INF/lib/doxia-sink-api-1.0.jar
WEB-INF/lib/maven-shared-utils-3.2.1.jar
WEB-INF/lib/commons-net-3.6.jar
WEB-INF/lib/commons-lang3-3.7.jar
WEB-INF/lib/org.eclipse.sisu.plexus-0.3.3.jar
WEB-INF/lib/maven-model-builder-3.5.4.jar
WEB-INF/lib/lib-jenkins-maven-artifact-manager-1.2.jar
WEB-INF/lib/maven3-agent-1.13.jar
WEB-INF/lib/javax.inject-1.jar
WEB-INF/lib/maven-embedder-3.5.4.jar
WEB-INF/lib/jsch.agentproxy.sshagent-0.0.9.jar
WEB-INF/lib/jsr250-api-1.0.jar
WEB-INF/lib/wagon-provider-api-3.3.2.jar
WEB-INF/lib/maven31-agent-1.13.jar
META-INF/maven/
META-INF/maven/org.jenkins-ci.main/
META-INF/maven/org.jenkins-ci.main/maven-plugin/
META-INF/maven/org.jenkins-ci.main/maven-plugin/pom.xml
META-INF/maven/org.jenkins-ci.main/maven-plugin/pom.properties
```
</details>
</summary>

We are already excluding a bunch of other dependencies from `lib-jenkins-maven-embedder`, such as `ant` for the same reason, so I think this is the right way to fix the issue, and I verified that the new path to `commons-io` is through `jenkins-core` using `mvn dependency:tree`, which is what we want. 

CC @olamy @car-roll for review.