### PR TITLE
Improve the message displayed on the UI about the default path to the…

### DIFF
--- a/src/main/java/hudson/maven/local_repo/DefaultLocalRepositoryLocator.java
+++ b/src/main/java/hudson/maven/local_repo/DefaultLocalRepositoryLocator.java
@@ -6,7 +6,10 @@ import hudson.maven.AbstractMavenBuild;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * Uses Maven's default local repository, which is actually <code>~/.m2/repository</code>
+ * Uses Maven's default local repository, which is usually <tt>~/.m2/repository</tt>,
+ * or the value of 'localRepository' in Maven's settings file, if defined.
+ *
+ * @see <a href="https://maven.apache.org/settings.html#Settings_Details">https://maven.apache.org/settings.html#Settings_Details</a>
  *
  * @author Kohsuke Kawaguchi
  */
@@ -24,7 +27,7 @@ public class DefaultLocalRepositoryLocator extends LocalRepositoryLocator {
     public static class DescriptorImpl extends LocalRepositoryLocatorDescriptor {
         @Override
         public String getDisplayName() {
-            return "Default (~/.m2/repository)";
+            return "Default (\"~/.m2/repository\", or the value of 'localRepository' in Maven's settings file, if defined)";
         }
     }
 }


### PR DESCRIPTION
The path to the maven repository is by default ~/.m2/repository, but it can be overridden in settings.xml, as per https://maven.apache.org/settings.html#Settings_Details.
