### PR TITLE
exclude spotbugs from lib-jenkins-maven-embedder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,10 @@ THE SOFTWARE.
           <groupId>org.apache.ant</groupId>
           <artifactId>ant</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Could properly be done upstream.