### PR TITLE
Replace esclave with agent in maven plugin (fr)

### DIFF
--- a/src/main/webapp/run-headless_fr.html
+++ b/src/main/webapp/run-headless_fr.html
@@ -1,9 +1,9 @@
 <div>
   <p>
     Si le build ne n&eacute,cessite pas un acc&egrave; &agrave; l'environnement graphique (s'il n'utilise que des outils
-    en ligne de commande) cette option peut &ecirc;tre activée.
+    en ligne de commande) cette option peut &ecirc;tre activ&eacute;e.
     <p>
     Cette option permet &agrave; Jenkins de lancer le processus de build en mode <em>'headless'</em>. Ceci est
     particuli&egrave;rement int&eacute;ressant sur OSX pour &eacute;viter qu'une ic&ocirc;ne Java prenne le focus en sautillant
-    dans le Dock. Cette option pourrait &agrave; l'avenir servir &agrave; s&eacute;lectionner un esclave adapt&eacute;.
+    dans le Dock. Cette option pourrait &agrave; l'avenir servir &agrave; s&eacute;lectionner un agent adapt&eacute;.
 </div>


### PR DESCRIPTION
The word esclave appeared in the French documentation for the maven plugin; I changed it to agent (consistent with previous PRs).