### PR TITLE
Move tests that depend on MavenModuleSet and MavenModuleSetBuild from Jenkins core to Maven Integration

### DIFF
--- a/src/test/java/hudson/bugs/seasar/Operation2174Test.java
+++ b/src/test/java/hudson/bugs/seasar/Operation2174Test.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.bugs.seasar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import hudson.maven.MavenModuleSet;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.tasks.BuildTrigger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+/**
+ * See http://ml.seasar.org/archives/operation/2008-November/004003.html
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class Operation2174Test {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    /** Tests that configuring a dependency from a freestyle to a maven project actually works. */
+    @Test
+    public void testBuildChains() throws Exception {
+        FreeStyleProject up = j.createFreeStyleProject("up");
+        MavenModuleSet dp = j.createProject(MavenModuleSet.class, "dp");
+
+        // designate 'dp' as the downstream in 'up'
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        webClient.getPage(up, "configure");
+
+        // configure downstream build
+        up.getPublishersList().add(new BuildTrigger("dp", false));
+        j.configRoundtrip((Item) up);
+
+        // verify that the relationship is set up
+        BuildTrigger trigger = up.getPublishersList().get(BuildTrigger.class);
+        assertEquals(trigger.getChildJobs(up), Collections.singletonList(dp));
+
+        // now go ahead and edit the downstream
+        j.configRoundtrip((Item) dp);
+
+        // verify that the relationship is set up
+        trigger = up.getPublishersList().get(BuildTrigger.class);
+        assertNotNull(trigger);
+        assertEquals(trigger.getChildJobs(up), Collections.singletonList(dp));
+    }
+}

--- a/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Victor Martinez.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import hudson.maven.MavenModuleSet;
+import hudson.model.FreeStyleProject;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+public class ListJobsCommandTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+    private CLICommandInvoker command;
+
+    @Before
+    public void setUp() {
+        CLICommand listJobsCommand = new ListJobsCommand();
+        command = new CLICommandInvoker(j, listJobsCommand);
+    }
+
+    @Issue("JENKINS-18393")
+    @Test
+    public void getAllJobsFromFolderWithMavenModuleSet() throws Exception {
+        MockFolder folder = j.createFolder("Folder");
+
+        folder.createProject(FreeStyleProject.class, "job1");
+        folder.createProject(FreeStyleProject.class, "job2");
+        folder.createProject(MavenModuleSet.class, "mvn");
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("Folder");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("job1"));
+        assertThat(result.stdout(), containsString("job2"));
+        assertThat(result.stdout(), containsString("mvn"));
+    }
+}

--- a/src/test/java/hudson/model/JobPropertyTest.java
+++ b/src/test/java/hudson/model/JobPropertyTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import hudson.maven.MavenModuleSet;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class JobPropertyTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Rule public LoggerRule logs = new LoggerRule();
+
+    @Test
+    @Issue("JENKINS-2398")
+    public void jobPropertySummaryIsShownInMavenModuleSetIndexPage() throws Exception {
+        assertJobPropertySummaryIsShownInIndexPage(MavenModuleSet.class);
+    }
+
+    private void assertJobPropertySummaryIsShownInIndexPage(Class<? extends TopLevelItem> type)
+            throws Exception {
+        JobPropertyImpl jp = new JobPropertyImpl("NeedleInPage");
+        Job<?, ?> project = (Job<?, ?>) j.jenkins.createProject(type, "job-test-case");
+        project.addProperty(jp);
+        project.save();
+
+        HtmlPage page = j.createWebClient().goTo("job/job-test-case");
+        WebAssert.assertTextPresent(page, "NeedleInPage");
+    }
+
+    public static class JobPropertyImpl extends JobProperty<Job<?, ?>> {
+        private final String propertyString;
+
+        public JobPropertyImpl(String propertyString) {
+            this.propertyString = propertyString;
+        }
+
+        public String getPropertyString() {
+            return propertyString;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends JobPropertyDescriptor {
+            @SuppressWarnings("rawtypes")
+            @Override
+            public boolean isApplicable(Class<? extends Job> jobType) {
+                return false;
+            }
+        }
+    }
+}

--- a/src/test/java/hudson/model/NodeTest.java
+++ b/src/test/java/hudson/model/NodeTest.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.maven.MavenModuleSet;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RunLoadCounter;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author Lucie Votypkova
+ */
+public class NodeTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void before() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+    }
+
+    /** Verify that the Label#getTiedJobCount does not perform a lazy loading operation. */
+    @Issue("JENKINS-26391")
+    @Test
+    public void testGetAssignedLabelWithJobs() throws Exception {
+        final Node node = j.createOnlineSlave();
+        node.setLabelString("label1 label2");
+        MavenModuleSet mavenProject = j.jenkins.createProject(MavenModuleSet.class, "p");
+        mavenProject.setAssignedLabel(j.jenkins.getLabel("label1"));
+        RunLoadCounter.prepare(mavenProject);
+        j.assertBuildStatus(Result.FAILURE, mavenProject.scheduleBuild2(0).get());
+        Integer labelCount = RunLoadCounter.assertMaxLoads(mavenProject, 0, new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                final Label label = j.jenkins.getLabel("label1");
+                label.reset(); // Make sure cached value is not used
+                return label.getTiedJobCount();
+            }
+        });
+
+        assertEquals("Should have only one job tied to label.", 1, labelCount.intValue());
+    }
+
+    /**
+     * Create two projects which have the same label and verify that both are accounted for when
+     * getting a count of the jobs tied to the current label.
+     */
+    @Issue("JENKINS-26391")
+    @Test
+    public void testGetAssignedLabelMultipleSlaves() throws Exception {
+        final Node node1 = j.createOnlineSlave();
+        node1.setLabelString("label1");
+        final Node node2 = j.createOnlineSlave();
+        node1.setLabelString("label1");
+
+        MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "p1");
+        final Label label = j.jenkins.getLabel("label1");
+        project.setAssignedLabel(label);
+        j.assertBuildStatus(Result.FAILURE, project.scheduleBuild2(0).get());
+
+        MavenModuleSet project2 = j.jenkins.createProject(MavenModuleSet.class, "p2");
+        project2.setAssignedLabel(label);
+        j.assertBuildStatus(Result.FAILURE, project2.scheduleBuild2(0).get());
+
+        label.reset(); // Make sure cached value is not used
+        assertEquals("Two jobs should be tied to this label.", 2, label.getTiedJobCount());
+    }
+
+    /**
+     * Verify that when a label is removed from a job that the tied job count does not include the
+     * removed job.
+     */
+    @Issue("JENKINS-26391")
+    @Test
+    public void testGetAssignedLabelWhenLabelRemoveFromProject() throws Exception {
+        final Node node = j.createOnlineSlave();
+        node.setLabelString("label1");
+
+        MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "p");
+        final Label label = j.jenkins.getLabel("label1");
+        project.setAssignedLabel(label);
+        j.assertBuildStatus(Result.FAILURE, project.scheduleBuild2(0).get());
+
+        project.setAssignedLabel(null);
+        label.reset(); // Make sure cached value is not used
+        assertEquals("Label1 should have no tied jobs after the job label was removed.", 0, label.getTiedJobCount());
+    }
+}

--- a/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Tom Huybrechts
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.tools;
+
+import hudson.EnvVars;
+import hudson.Functions;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.DumbSlave;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Maven;
+import hudson.tasks.Maven.MavenInstallation;
+import hudson.tasks.Shell;
+
+import jenkins.model.Jenkins;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.ToolInstallations;
+
+/**
+ * This class tests that environment variables from node properties are applied, and that the
+ * priority is maintained: parameters > slave node properties > master node properties
+ */
+public class ToolLocationNodePropertyTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    private DumbSlave slave;
+    private FreeStyleProject project;
+
+    @Test
+    public void maven() throws Exception {
+        MavenInstallation maven = ToolInstallations.configureDefaultMaven();
+        String mavenPath = maven.getHome();
+        Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(new MavenInstallation("maven", "THIS IS WRONG", JenkinsRule.NO_PROPERTIES));
+
+        project.getBuildersList().add(new Maven("--version", "maven"));
+        configureDumpEnvBuilder();
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, build);
+
+        ToolLocationNodeProperty property =
+                new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation(j.jenkins.getDescriptorByType(MavenInstallation.DescriptorImpl.class), "maven", mavenPath));
+        slave.getNodeProperties().add(property);
+
+        build = project.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    private void configureDumpEnvBuilder() {
+        if (Functions.isWindows()) {
+            project.getBuildersList().add(new BatchFile("set"));
+        } else {
+            project.getBuildersList().add(new Shell("export"));
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        EnvVars env = new EnvVars();
+        // we don't want Maven, Ant, etc. to be discovered in the path for this test to work,
+        // but on Unix these tools rely on other basic Unix tools (like env) for its operation,
+        // so empty path breaks the test.
+        env.put("PATH", "/bin:/usr/bin");
+        env.put("M2_HOME", "empty");
+        slave = j.createSlave(new LabelAtom("slave"), env);
+        project = j.createFreeStyleProject();
+        project.setAssignedLabel(slave.getSelfLabel());
+    }
+}

--- a/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
+++ b/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
@@ -1,0 +1,91 @@
+package jenkins.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.logging.Level;
+import java.util.stream.Stream;
+
+/**
+ * Since JENKINS-50164, Jenkins#workspacesDir and Jenkins#buildsDir had their associated UI deleted.
+ * So instead of configuring through the UI, we now have to use sysprops for this.
+ *
+ * <p>So this test class uses a {@link RestartableJenkinsRule} to check the behaviour of this
+ * sysprop being present or not between two restarts.
+ */
+public class JenkinsBuildsAndWorkspacesDirectoriesTest {
+
+    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Rule public LoggerRule loggerRule = new LoggerRule();
+
+    @Before
+    public void before() {
+        clearSystemProperties();
+    }
+
+    @After
+    public void after() {
+        clearSystemProperties();
+    }
+
+    private void clearSystemProperties() {
+        Stream.of(Jenkins.BUILDS_DIR_PROP, Jenkins.WORKSPACES_DIR_PROP)
+                .forEach(System::clearProperty);
+    }
+
+    private void setWorkspacesDirProperty(String workspacesDir) {
+        System.setProperty(Jenkins.WORKSPACES_DIR_PROP, workspacesDir);
+    }
+
+    private void setBuildsDirProperty(String buildsDir) {
+        System.setProperty(Jenkins.BUILDS_DIR_PROP, buildsDir);
+    }
+
+    private boolean logWasFound(String searched) {
+        return loggerRule.getRecords().stream()
+                .anyMatch(record -> record.getMessage().contains(searched));
+    }
+
+    @Test
+    @Issue("JENKINS-12251")
+    public void testItemFullNameExpansion() {
+        loggerRule.record(Jenkins.class, Level.WARNING)
+                .record(Jenkins.class, Level.INFO)
+                .capture(1000);
+
+        story.then(steps -> {
+            assertTrue(story.j.getInstance().isDefaultBuildDir());
+            assertTrue(story.j.getInstance().isDefaultWorkspaceDir());
+            setBuildsDirProperty("${JENKINS_HOME}/test12251_builds/${ITEM_FULL_NAME}");
+            setWorkspacesDirProperty("${JENKINS_HOME}/test12251_ws/${ITEM_FULL_NAME}");
+        });
+
+        story.then(steps -> {
+            assertTrue(JenkinsBuildsAndWorkspacesDirectoriesTest.this.logWasFound("Changing builds directories from "));
+            assertFalse(story.j.getInstance().isDefaultBuildDir());
+            assertFalse(story.j.getInstance().isDefaultWorkspaceDir());
+
+            // build a dummy project
+            MavenModuleSet m = story.j.jenkins.createProject(MavenModuleSet.class, "p");
+            m.setScm(new ExtractResourceSCM(getClass().getResource("/simple-projects.zip")));
+            MavenModuleSetBuild b = m.scheduleBuild2(0).get();
+
+            // make sure these changes are effective
+            assertTrue(b.getWorkspace().getRemote().contains("test12251_ws"));
+            assertTrue(b.getRootDir().toString().contains("test12251_builds"));
+        });
+    }
+}

--- a/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.tasks;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Maven;
+import hudson.tasks.Maven.MavenInstallation;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.ToolInstallations;
+
+import java.io.IOException;
+
+public class SimpleBuildWrapperTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void disposerWithMaven() throws Exception {
+        MavenInstallation maven = ToolInstallations.configureDefaultMaven();
+        r.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(maven);
+        MavenModuleSet p = r.createProject(MavenModuleSet.class, "p");
+        p.getBuildWrappersList().add(new PreCheckoutWrapperWithDisposer());
+        p.setIsFingerprintingDisabled(true);
+        p.setIsArchivingDisabled(true);
+        p.setScm(new ExtractResourceSCM(getClass().getResource("/simple-projects.zip")));
+        MavenModuleSetBuild b = p.scheduleBuild2(0).get();
+        r.assertLogContains("ran DisposerImpl #1", b);
+        r.assertLogNotContains("ran DisposerImpl #2", b);
+    }
+    public static class WrapperWithDisposer extends SimpleBuildWrapper {
+        @Override public void setUp(Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
+            context.setDisposer(new DisposerImpl());
+        }
+        private static final class DisposerImpl extends Disposer {
+            private static final long serialVersionUID = 1;
+            private int tearDownCount = 0;
+            @Override public void tearDown(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+                listener.getLogger().println("ran DisposerImpl #" + (++tearDownCount));
+            }
+        }
+        @TestExtension({ "disposer", "failedJobWithInterruptedDisposer" }) public static class DescriptorImpl extends BuildWrapperDescriptor {
+            @Override public boolean isApplicable(AbstractProject<?,?> item) {
+                return true;
+            }
+        }
+    }
+    public static class PreCheckoutWrapperWithDisposer extends WrapperWithDisposer {
+        @Override
+        protected boolean runPreCheckout() {
+            return true;
+        }
+        @TestExtension({ "disposerForPreCheckoutWrapper", "disposerForPreCheckoutWrapperWithScmError" }) public static class DescriptorImpl extends BuildWrapperDescriptor {
+            @Override public boolean isApplicable(AbstractProject<?,?> item) {
+                return true;
+            }
+        }
+    }
+}

--- a/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -78,7 +78,7 @@ public class SimpleBuildWrapperTest {
                 listener.getLogger().println("ran DisposerImpl #" + (++tearDownCount));
             }
         }
-        @TestExtension({ "disposer", "failedJobWithInterruptedDisposer" }) public static class DescriptorImpl extends BuildWrapperDescriptor {
+        @TestExtension("disposerWithMaven") public static class DescriptorImpl extends BuildWrapperDescriptor {
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }
@@ -89,7 +89,7 @@ public class SimpleBuildWrapperTest {
         protected boolean runPreCheckout() {
             return true;
         }
-        @TestExtension({ "disposerForPreCheckoutWrapper", "disposerForPreCheckoutWrapperWithScmError" }) public static class DescriptorImpl extends BuildWrapperDescriptor {
+        @TestExtension("disposerWithMaven") public static class DescriptorImpl extends BuildWrapperDescriptor {
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }

--- a/src/test/java/lib/hudson/ListScmBrowsersTest.java
+++ b/src/test/java/lib/hudson/ListScmBrowsersTest.java
@@ -1,0 +1,46 @@
+package lib.hudson;
+
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
+import com.gargoylesoftware.htmlunit.html.HtmlOption;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+
+import hudson.maven.MavenModuleSet;
+import hudson.model.Item;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class ListScmBrowsersTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void selectBoxesUnique_MavenProject() throws Exception {
+        check(j.jenkins.createProject(MavenModuleSet.class, "p"));
+    }
+
+    private void check(Item p) throws IOException, SAXException {
+        HtmlPage page = j.createWebClient().getPage(p, "configure");
+        List<HtmlSelect> selects = DomNodeUtil.selectNodes(page, "//select");
+        assertTrue(selects.size() > 0);
+        for (HtmlSelect select : selects) {
+            Set<String> title = new HashSet<>();
+            for (HtmlOption o : select.getOptions()) {
+                assertTrue("Duplicate entry: " + o.getText(), title.add(o.getText()));
+            }
+        }
+    }
+}

--- a/src/test/resources/hudson/model/JobPropertyTest/JobPropertyImpl/summary.jelly
+++ b/src/test/resources/hudson/model/JobPropertyTest/JobPropertyImpl/summary.jelly
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+${it.propertyString}
+</j:jelly>


### PR DESCRIPTION
### Background

See [jenkinsci/jenkins#5118 (comment)](https://github.com/jenkinsci/jenkins/pull/5118#pullrequestreview-551495129). The tests in Jenkins core depend on an old version of `maven-plugin`. This pollutes the dependency tree for the tests in Jenkins core, causing `RequireUpperBoundDeps` issues and complicating maintenance.

### Problem

A number of tests in Jenkins core depend on `hudson.maven.MavenModuleSet` or `hudson.maven.MavenModuleSetBuild`. These classes were previously in Jenkins core before they were extracted to `maven-plugin`. However, the corresponding tests were never moved to `maven-plugin`. As a result, the tests are no longer in the same repository as the code under test.

### Solution

Move the tests in Jenkins core that depend on `hudson.maven.MavenModuleSet` or `hudson.maven.MavenModuleSetBuild` to `maven-plugin`.

### Implementation

A handful of these tests were already disabled for several years; we do not make any effort to revive these or move them. Rather we only move the tests that are still running regularly. Below is a detailed description of the change:

- `PluginManagerTest#optionalMavenDependency`: This test relies on `hudson.maven.agent.AbortException` with a comment stating: "this actually doesn't really test what we need." The test seemed pointless, so we deleted it.
- `Operation2174Test#testBuildChains`: Moved to `maven-plugin`.
- `ListJobsCommandTest#getAllJobsFromFolderWithMavenModuleSet`: Moved to `maven-plugin`.
- `GetEnvironmentOutsideBuildTest#testMaven`: The entire test class is disabled with a comment stating: "It's unfortunately not working, yet, as whenJenkinsMasterHasNoExecutors is not working as expected." The test seemed pointless, so we deleted it.
- `HelpLinkTest#mavenConfig`: The entire test class is disabled with a comment stating: "Excluding test to be able to ship 2.0 beta 1. Jenkins confirms that this test is now taking 45mins to complete." The test seemed pointless, so we deleted it.
- `JobPropertyTest#jobPropertySummaryIsShownInMavenModuleSetIndexPage`: Moved to `maven-plugin`.
- `NodeTest#testGetAssignedLabelWithJobs`, `NodeTest#testGetAssignedLabelMultipleSlaves`, and `NodeTest#testGetAssignedLabelWhenLabelRemoveFromProject`: Moved to `maven-plugin`.
- `BuildTriggerTest#mavenBuildTrigger` and `BuildTriggerTest#mavenTriggerEvenWhenUnstable`: These tests are disabled with a comment stating: "Fails on CI due to maven trying to download from maven central on http, which is no longer supported". The tests seemed pointless, so we deleted them.
- `ToolLocationNodePropertyTest#maven`: Moved to `maven-plugin`.
- `ToolLocationNodePropertyTest#nativeMaven`: This test is disabled with a comment stating: "Fails on CI due to maven trying to download from maven central on http, which is no longer supported". The test seemed pointless, so we deleted it.
- `JenkinsBuildsAndWorkspacesDirectoriesTest#testItemFullNameExpansion`: Moved to `maven-plugin`.
- `SimpleBuildWrapperTest#disposerWithMaven`: Moved to `maven-plugin`.
- `ListScmBrowsersTest#selectBoxesUnique_MavenProject`: Moved to `maven-plugin`.