### PR TITLE
[JENKINS-65014] Avoid NPE when StringParameterDefinition.defaultValue == null

### DIFF
--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -1168,7 +1168,10 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                 for (ParameterDefinition parameterDefinition : parametersDefinitionProperty.getParameterDefinitions()) {
                     // those must used as env var
                     if (parameterDefinition instanceof StringParameterDefinition) {
-                        this.properties.put( "env." + parameterDefinition.getName(), ((StringParameterDefinition)parameterDefinition).getDefaultValue() );
+                        String defaultValue = ((StringParameterDefinition)parameterDefinition).getDefaultValue();
+                        if (defaultValue != null) {
+                            this.properties.put("env." + parameterDefinition.getName(), defaultValue);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
[JENKINS-65014](https://issues.jenkins.io/browse/JENKINS-65014): reported regression from https://github.com/jenkinsci/jenkins/pull/5275. Treating it as a plugin bug because there was no nullness indication on `StringParameterDefinition.getDefaultValue`, and as seen in https://github.com/jenkinsci/jenkins/blob/38ce5ce7cda90dc298109d45fa46eb9f3e69682b/core/src/main/java/hudson/model/StringParameterDefinition.java#L47-L49 and https://github.com/jenkinsci/jenkins/blob/38ce5ce7cda90dc298109d45fa46eb9f3e69682b/core/src/main/java/hudson/model/StringParameterDefinition.java#L82 it was already possible for it to be null.
