### PR TITLE
JENKINS-66136: Performance of rebuildDependencyGraph for MavenModule

### DIFF
--- a/src/main/java/hudson/maven/MavenModule.java
+++ b/src/main/java/hudson/maven/MavenModule.java
@@ -525,7 +525,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
                 for (MavenModule m : getAllMavenModules()) {
                     if(m.isDisabled())  continue;
                     ModuleDependency moduleDependency = m.asDependency().withUnknownVersion();
-                    data.allModules.put(moduleDependency,m);
+                    data.put(moduleDependency,m);
                 }
                 data.withUnknownVersions = true;
             }
@@ -686,24 +686,28 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
          */
         private final Map<ModuleDependency,MavenModule> allModules;
 
+        private Multimap<ModuleName,ModuleDependency> byName = HashMultimap.create();
+        
         public MavenDependencyComputationData(Map<ModuleDependency, MavenModule> modules) {
             this.allModules = modules;
+            for (ModuleDependency dependency : allModules.keySet()) {
+            	byName.put(dependency.getName(),dependency);
+            }
         }
+        
+        public void put(ModuleDependency moduleDependency, MavenModule m) {
+			this.allModules.put(moduleDependency, m);
+			byName.put(moduleDependency.getName(), moduleDependency);
+		}
 
-        /**
+		/**
          * Builds a map of all the modules, keyed against the groupId and artifactId. The values are a list of modules
          * that match this criteria.
          *
          * @return {@link #allModules} keyed by their {@linkplain ModuleName names}.
          */
         private Multimap<ModuleName,ModuleDependency> byName() {
-            Multimap<ModuleName,ModuleDependency> map = HashMultimap.create();
-
-            for (ModuleDependency dependency : allModules.keySet()) {
-                map.put(dependency.getName(),dependency);
-            }
-
-            return map;
+            return this.byName;
         }
     }
 


### PR DESCRIPTION
maintain MultiHashMap in MavenDependencyComputationData to avoid
expensive recomputations


- [x] Please describe what you did

maintain MultiHashMap in MavenDependencyComputationData to avoid
expensive recomputations
Solves a severe performance problem (>20min waiting) for large Maven builds.

- [x ] Link to relevant issues in GitHub or Jira
https://issues.jenkins.io/browse/JENKINS-66136

- [x] Link to relevant pull requests, esp. upstream and downstream changes
 https://github.com/aubelix/maven-plugin/commit/09ba726cbb01fcf722d09c8eafd29c5bce0d3118

- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

The runtime for the recalculation decreased from >20 minutes to 1 second for our Jenkins Server (>4000 Maven Projects with 10-20 modules for each) after installing this fix. Upstream and downstream project were correct after the build.

