### PR TITLE
Integrate 3.15.1 into default branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->
   <artifactId>maven-plugin</artifactId><!-- for the same reason, artifactId is against the convention -->
-  <version>3.15.1</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Maven Integration plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>https://github.com/jenkinsci/maven-plugin</url>
 
   <properties>
-    <revision>3.16</revision>
+    <revision>3.15.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/maven-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
@@ -972,7 +972,7 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>http://github.com/${gitHubRepo}</url>
-    <tag>maven-plugin-3.15.1</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->
   <artifactId>maven-plugin</artifactId><!-- for the same reason, artifactId is against the convention -->
-  <version>${revision}${changelist}</version>
+  <version>3.15.1</version>
   <packaging>hpi</packaging>
 
   <name>Maven Integration plugin</name>
@@ -972,7 +972,7 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>http://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
+    <tag>maven-plugin-3.15.1</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>https://github.com/jenkinsci/maven-plugin</url>
 
   <properties>
-    <revision>3.15.2</revision>
+    <revision>3.16</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/maven-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>

--- a/src/main/java/hudson/maven/MavenBuildProxy.java
+++ b/src/main/java/hudson/maven/MavenBuildProxy.java
@@ -80,17 +80,20 @@ public interface MavenBuildProxy {
     /**
      * Root directory of the build.
      *
-     * @see MavenBuild#getRootDir() 
+     * @see MavenBuild#getRootDir()
+     * @see MavenReporterDescriptor#reportedFilePattern
      */
     FilePath getRootDir();
 
     /**
      * Root directory of the parent of this build.
+     * @see MavenReporterDescriptor#reportedFilePattern
      */
     FilePath getProjectRootDir();
 
     /**
      * Root directory of the owner {@link MavenModuleSet}
+     * @see MavenReporterDescriptor#reportedFilePattern
      */
     FilePath getModuleSetRootDir();
 

--- a/src/main/java/hudson/maven/MavenReporterDescriptor.java
+++ b/src/main/java/hudson/maven/MavenReporterDescriptor.java
@@ -23,6 +23,7 @@
  */
 package hudson.maven;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.maven.reporters.MavenArtifactArchiver;
 import hudson.model.Descriptor;
 import hudson.model.Describable;
@@ -104,4 +105,17 @@ public abstract class MavenReporterDescriptor extends Descriptor<MavenReporter> 
         // use getDescriptorList and not getExtensionList to pick up legacy instances
         return Jenkins.get().getDescriptorList(MavenReporter.class);
     }
+
+    /**
+     * File patterns this reporter might create when running inside the Maven JVM.
+     * Applies to usages from {@link MavenReporter#postBuild} and similar callbacks
+     * of {@link MavenBuildProxy#getRootDir}, {@link MavenBuildProxy#getProjectRootDir}, and {@link MavenBuildProxy#getModuleSetRootDir}.
+     * (But not {@link MavenBuildProxy#getArtifactsDir}, which should not be used anyway.)
+     * @return an Ant-style file pattern of files we expect to copy, or null if not applicable (default)
+     */
+    @CheckForNull
+    public String reportedFilePattern() {
+        return null;
+    }
+
 }

--- a/src/main/java/hudson/maven/reporters/MavenJavadocArchiver.java
+++ b/src/main/java/hudson/maven/reporters/MavenJavadocArchiver.java
@@ -72,6 +72,12 @@ public class MavenJavadocArchiver extends AbstractMavenJavadocArchiver {
         public MavenJavadocArchiver newAutoInstance(MavenModule module) {
             return new MavenJavadocArchiver();
         }
+
+        @Override
+        public String reportedFilePattern() {
+            return "javadoc/";
+        }
+
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
+++ b/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
@@ -187,6 +187,12 @@ public class MavenSiteArchiver extends MavenReporter {
         public MavenSiteArchiver newAutoInstance(MavenModule module) {
             return new MavenSiteArchiver();
         }
+
+        @Override
+        public String reportedFilePattern() {
+            return "site/";
+        }
+
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/maven/reporters/MavenTestJavadocArchiver.java
+++ b/src/main/java/hudson/maven/reporters/MavenTestJavadocArchiver.java
@@ -72,6 +72,12 @@ public class MavenTestJavadocArchiver extends AbstractMavenJavadocArchiver {
         public MavenTestJavadocArchiver newAutoInstance(MavenModule module) {
             return new MavenTestJavadocArchiver();
         }
+
+        @Override
+        public String reportedFilePattern() {
+            return "test-javadoc/";
+        }
+
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/test/java/hudson/maven/reporters/BlockSlaveToMasterFileCallable.java
+++ b/src/test/java/hudson/maven/reporters/BlockSlaveToMasterFileCallable.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.maven.reporters;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.remoting.Callable;
+import hudson.remoting.ChannelBuilder;
+import jenkins.security.ChannelConfigurator;
+import jenkins.util.JenkinsJVM;
+import org.jenkinsci.remoting.CallableDecorator;
+
+/**
+ * Prevents {@link FilePath#act} (or {@link FilePath#actAsync}) from running in a controller → agent direction during tests, to make sure we do not rely on them.
+ */
+public class BlockSlaveToMasterFileCallable extends CallableDecorator {
+
+    @Override public <V, T extends Throwable> Callable<V, T> userRequest(Callable<V, T> op, Callable<V, T> stem) {
+        if (op.getClass().getName().equals("hudson.FilePath$FileCallableWrapper") && JenkinsJVM.isJenkinsJVM()) {
+            throw new SecurityException("blocked");
+        }
+        return stem;
+    }
+
+    @Extension public static class ChannelConfiguratorImpl extends ChannelConfigurator {
+
+        @Override public void onChannelBuilding(ChannelBuilder builder, @Nullable Object context) {
+            builder.with(new BlockSlaveToMasterFileCallable());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This has improved compatibility with https://github.com/jenkinsci/remoting-security-workaround-plugin#affected-functionality. Plus all the agent-to-controller stuff is a nightmare anyway.

Should be merged using merge-commit, not using squash-merge or rebase-merge, to retain https://github.com/jenkinsci/maven-plugin/releases/tag/maven-plugin-3.15.1 in the history of the default branch.