### PR TITLE
No need to override `reuseForks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.29</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
 
@@ -835,14 +835,6 @@ THE SOFTWARE.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- not reuse because Mockito record stuff statically and some are changing between tests so it suc... -->
-            <reuseForks>false</reuseForks>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
+++ b/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RandomlyFails;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -65,7 +65,7 @@ public class SurefireArchiverUnitTest {
         this.archiver = new SurefireArchiver();
         this.build = mock(MavenBuild.class);
         final List<Action> actions = new ArrayList<>();
-        when(build.getAction(Matchers.any(Class.class))).thenAnswer( (Answer<Action>) invocation -> {
+        when(build.getAction(ArgumentMatchers.any(Class.class))).thenAnswer( (Answer<Action>) invocation -> {
             Class<?> type = (Class<?>) invocation.getArguments()[0];
             for (Action action : actions) {
                 if (type.isInstance(action)) {
@@ -103,7 +103,7 @@ public class SurefireArchiverUnitTest {
         
         MojoInfo spy = spy(info);
         
-        doReturn(Boolean.FALSE).when(spy).getConfigurationValue(Matchers.anyString(), Matchers.eq(Boolean.class));
+        doReturn(Boolean.FALSE).when(spy).getConfigurationValue(ArgumentMatchers.anyString(), ArgumentMatchers.eq(Boolean.class));
         return spy;
     }
     


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/453.