### PR TITLE
Allow modern Jenkins versions to override PNG with SVG icons

### DIFF
--- a/src/main/resources/hudson/maven/MavenBuild/actions.jelly
+++ b/src/main/resources/hudson/maven/MavenBuild/actions.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:task icon="images/24x24/gear.png" href="${buildUrl.baseUrl}/executedMojos" title="${%Executed Mojos}" />
+  <l:task icon="icon-gear2 icon-md" href="${buildUrl.baseUrl}/executedMojos" title="${%Executed Mojos}" />
   <!-- include super class definition -->
   <st:include page="/hudson/model/Actionable/actions.jelly" />
 </j:jelly>

--- a/src/main/resources/hudson/maven/MavenBuild/executedMojos.jelly
+++ b/src/main/resources/hudson/maven/MavenBuild/executedMojos.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
               <tr>
                 <td>
                   <a href="${m.getPluginLink(cache)}">
-                    <img src="${imagesURL}/24x24/gear.png" alt="" height="24" width="24"/>
+                    <l:icon class="icon-gear2 icon-md" alt="" />
                     ${m.groupId}:${m.artifactId}
                   </a>
                 </td>
@@ -70,7 +70,7 @@ THE SOFTWARE.
                 <td align="center">${m.readableExecutionId}</td>
                 <td data="${m.duration}">${m.durationString}</td>
                 <td align="center">
-                  <a href="${rootURL}/fingerprint/${m.digest}/"><img src="${imagesURL}/16x16/fingerprint.png" alt="${%fingerprint}" height="16" width="16" /></a>
+                  <a href="${rootURL}/fingerprint/${m.digest}/"><l:icon class="icon-fingerprint icon-md" alt="${%fingerprint}" /></a>
                 </td>
               </tr>
             </j:forEach>

--- a/src/main/resources/hudson/maven/MavenModuleSet/actions.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/actions.jelly
@@ -26,12 +26,12 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${it.hasDisabledModule()}">
     <l:isAdmin>
-      <l:task icon="images/24x24/delete-document.png" href="${url}/doDeleteAllDisabledModules" title="${%Delete All Disabled Modules}" post="true" requiresConfirmation="true" confirmationMessage="${%Are you sure about deleting all the disabled modules?}"/>
+      <l:task icon="icon-delete-document icon-md" href="${url}/doDeleteAllDisabledModules" title="${%Delete All Disabled Modules}" post="true" requiresConfirmation="true" confirmationMessage="${%Are you sure about deleting all the disabled modules?}"/>
     </l:isAdmin>
   </j:if>
   <!-- Icon TBD -->
   <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-  <l:task icon="images/24x24/document.png" href="${url}/modules" title="${%Modules}" />
+  <l:task icon="icon-document icon-md" href="${url}/modules" title="${%Modules}" />
 
   <!-- include super class definition -->
   <st:include page="/hudson/model/Actionable/actions.jelly" />

--- a/src/main/resources/hudson/maven/MavenProbeAction/sidepanel.jelly
+++ b/src/main/resources/hudson/maven/MavenProbeAction/sidepanel.jelly
@@ -26,11 +26,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/document.png" href="systemProperties" title="${%System Properties}" />
-      <l:task icon="images/24x24/document.png" href="envVars" title="${%Environment Variables}" />
-      <l:task icon="images/24x24/document.png" href="threads" title="${%Thread Dump}" />
+      <l:task icon="icon-document icon-md" href="systemProperties" title="${%System Properties}" />
+      <l:task icon="icon-document icon-md" href="envVars" title="${%Environment Variables}" />
+      <l:task icon="icon-document icon-md" href="threads" title="${%Thread Dump}" />
       <l:hasPermission permission="${app.RUN_SCRIPTS}">
-        <l:task icon="images/24x24/notepad.png" href="script" title="${%Script Console}" />
+        <l:task icon="icon-notepad icon-md" href="script" title="${%Script Console}" />
       </l:hasPermission>
     </l:tasks>
   </l:side-panel>

--- a/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/badge.jelly
+++ b/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/badge.jelly
@@ -26,9 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:test="/lib/test">
   <j:if test="${it.hasBadge()}">
     <a href="${link}redeploy/">
-      <img width="16" height="16" alt="[deployed]"
-           tooltip="${%Deployed to repository}"
-           src="${imagesURL}/16x16/redo.png"/>
+      <l:task icon="icon-redo icon-sm" title="${%Deployed to repository}" />
     </a>
   </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index.jelly
+++ b/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     </l:side-panel>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/redo.png" width="48" height="48" alt="" />
+        <l:icon class="icon-redo icon-xlg" />
         ${%Redeploy Artifacts}
       </h1>
 


### PR DESCRIPTION
Replace icon paths to allow modern Jenkins versions to override these and put in SVGs over PNGs where applicable, in preparation of https://github.com/jenkinsci/jenkins/pull/5778

| Before | After |
| ----------- | ----------- |
| ![](https://i.imgur.com/P8SOus4.png) | ![](https://i.imgur.com/yCET2Xb.png) |
| ![](https://i.imgur.com/XdCxvJ5.png) | ![](https://i.imgur.com/reUD0Uu.png) |
| ![](https://i.imgur.com/SuV5jID.png) | ![](https://i.imgur.com/BhL7lcM.png) |
| ![](https://i.imgur.com/ee4Rd5p.png) | ![](https://i.imgur.com/9lH08HX.png)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue