### PR TITLE
Utilize modern build status, update test table design and add dropdown menu to modules

### DIFF
--- a/src/main/java/hudson/maven/MavenProbeAction.java
+++ b/src/main/java/hudson/maven/MavenProbeAction.java
@@ -66,7 +66,7 @@ public final class MavenProbeAction implements Action {
 
     public String getIconFileName() {
         if(channel==null)   return null;
-        return "computer.png";
+        return "computer.svg";
     }
 
     public String getDisplayName() {

--- a/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
+++ b/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
@@ -141,7 +141,7 @@ public abstract class MavenAbstractArtifactRecord<T extends AbstractBuild<?,?>> 
         @Exported
         public BallColor getIconColor() {
             if(result==null)
-                return BallColor.GREY_ANIME;
+                return BallColor.NOTBUILT_ANIME;
             else
                 return result.color;
         }

--- a/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
+++ b/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
@@ -169,7 +169,7 @@ public abstract class MavenAbstractArtifactRecord<T extends AbstractBuild<?,?>> 
     }
 
     public final String getIconFileName() {
-        return getACL().hasPermission(getPermission()) ? "redo.png" : null;
+        return getACL().hasPermission(getPermission()) ? "redo.svg" : null;
     }
 
     public final String getDisplayName() {

--- a/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
+++ b/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
@@ -163,7 +163,7 @@ public class MavenSiteArchiver extends MavenReporter {
 
         public String getIconFileName() {
             if(getSiteDir(project).exists())
-                return "help.png";
+                return "help.svg";
             else
                 // hide it since we don't have site yet.
                 return null;
@@ -174,7 +174,7 @@ public class MavenSiteArchiver extends MavenReporter {
          */
         public DirectoryBrowserSupport doDynamic() {
             File siteDir = getSiteDir(project);
-            return new DirectoryBrowserSupport(project, new FilePath(siteDir), project.getDisplayName() + " site", "help.gif", !new File(siteDir, "index.html").isFile());
+            return new DirectoryBrowserSupport(project, new FilePath(siteDir), project.getDisplayName() + " site", "help.svg", !new File(siteDir, "index.html").isFile());
         }
     }
 

--- a/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
             ${act.displayName}
           </t:summary>
         </j:forEach>
-        <t:summary icon="folder.png" href="ws/" permission="${it.WORKSPACE}">
+        <t:summary icon="folder.svg" href="ws/" permission="${it.WORKSPACE}">
           ${%Workspace}
         </t:summary>
 
@@ -50,13 +50,13 @@ THE SOFTWARE.
             build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
             permission="${it.lastSuccessfulBuild.ARTIFACTS}" />
 
-        <t:summary icon="notepad.png" href="changes">
+        <t:summary icon="notepad.svg" href="changes">
           ${%Recent Changes}
         </t:summary>
 
         <j:set var="tr" value="${it.testResultAction}"/>
         <j:if test="${tr!=null}">
-          <t:summary icon="clipboard.png">
+          <t:summary icon="clipboard.svg">
             <a href="lastBuild/testReport/">${%Latest Test Result}</a>
             <st:nbsp/>
             <t:test-result it="${tr}" />

--- a/src/main/resources/hudson/maven/MavenModuleSetBuild/main.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSetBuild/main.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <h2>${%Module Builds}</h2>
   <table>
     <j:forEach var="m" items="${it.moduleBuilds}">
@@ -30,7 +30,7 @@ THE SOFTWARE.
         <j:choose>
           <j:when test="${m.value.size()==0}">
             <td class="no-wrap">
-              <img src="${imagesURL}/16x16/grey.png" alt="" height="16" width="16"/>
+              <l:icon class="icon-nobuilt icon-sm" alt="" />
               <st:nbsp/>${m.key.displayName} (${%noRun})
             </td><td>
             </td>
@@ -39,8 +39,7 @@ THE SOFTWARE.
             <j:set var="mb" value="${m.value.get(0)}"/>
             <td class="no-wrap">
               <a href="${m.key.shortUrl}">
-                <img src="${imagesURL}/16x16/${mb.buildStatusUrl}"
-                     alt="${mb.iconColor.description}" height="16" width="16"/>
+                <l:icon class="${mb.iconColor.iconClassName} icon-sm" alt="${mb.iconColor.description}" />
               </a>
               <st:nbsp/>
               <a href="${m.key.shortUrl}">

--- a/src/main/resources/hudson/maven/MavenModuleSetBuild/main.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSetBuild/main.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
                 <l:icon class="${mb.iconColor.iconClassName} icon-sm" alt="${mb.iconColor.description}" />
               </a>
               <st:nbsp/>
-              <a href="${m.key.shortUrl}">
+              <a href="${m.key.shortUrl}" class="model-link">
                 ${m.key.displayName}
               </a>
             </td><td data="${mb.duration}">

--- a/src/main/resources/hudson/maven/reporters/SurefireAggregatedReport/index.jelly
+++ b/src/main/resources/hudson/maven/reporters/SurefireAggregatedReport/index.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:test="/lib/test">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:test="/lib/test">
   <l:layout>
     <st:include it="${it.owner}" page="sidepanel.jelly" />
     <l:main-panel>
@@ -32,14 +32,16 @@ THE SOFTWARE.
       <j:set var="prev" value="${it.previousResult}" />
       <test:bar />
 
-      <table class="pane sortable bigtable" id="testresult">
-        <tr>
-          <td class="pane-header">${%Module}</td>
-          <td class="pane-header" style="width:5em">${%Fail}</td>
-          <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
-          <td class="pane-header" style="width:5em">${%Total}</td>
-          <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
-        </tr>
+      <table class="pane sortable jenkins-table" id="testresult">
+        <thead>
+          <tr>
+            <td class="pane-header">${%Module}</td>
+            <td class="pane-header" style="width:5em">${%Fail}</td>
+            <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+            <td class="pane-header" style="width:5em">${%Total}</td>
+            <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+          </tr>
+        </thead>
         <tbody>
           <j:forEach var="c" items="${it.children}">
             <j:set var="p" value="${it.getChildReport(c)}"/>


### PR DESCRIPTION
The change proposed utilizes the modernized build status icons at the "Module Builds" tab and updates the design of the test table.

<details>
<summary>Current look of "Module Builds"</summary>

![](https://i.imgur.com/9YXfYBw.png)

</details>

<details>
<summary>Proposed change for "Module Builds"</summary>

![](https://i.imgur.com/NiU1E6J.png)

Building state:
![](https://i.imgur.com/aU9agiX.png)

</details>


- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue