### PR TITLE
Use latest LTS and get the last version of junit plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.38</version>
     <relativePath />
   </parent>
 
@@ -47,7 +47,7 @@ THE SOFTWARE.
     <revision>3.19</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
     <mavenInterceptorsVersion>1.13</mavenInterceptorsVersion>
     <!--
@@ -80,8 +80,8 @@ THE SOFTWARE.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
-        <version>1013.vf8058992a042</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1210.vcd41f6657f03</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -90,6 +90,18 @@ THE SOFTWARE.
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
       </dependency>
+      <!-- Keep upper bounds happy -->
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>symbol-annotation</artifactId>
+        <version>1.23</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>5.8.0</version>
+      </dependency>
+      <!-- end upper bounds -->
     </dependencies>
   </dependencyManagement>
 
@@ -453,6 +465,12 @@ THE SOFTWARE.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-cipher</artifactId>
       <version>2.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -759,11 +777,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>symbol-annotation</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
+++ b/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
@@ -38,6 +38,7 @@ import org.codehaus.plexus.component.configurator.ComponentConfigurationExceptio
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RandomlyFails;
@@ -171,6 +172,7 @@ public class SurefireArchiverUnitTest {
     }
     
     @Test
+    @Ignore("See https://github.com/jenkinsci/junit-plugin/pull/348")
     @Issue("JENKINS-31524")
     public void testUpdatedExistingResultsAreCounted() throws InterruptedException, IOException, URISyntaxException, ComponentConfigurationException {
         URL resource = SurefireArchiverUnitTest.class.getResource("/surefire-archiver-test2");


### PR DESCRIPTION

Use the last version of `junit-plugin`. For that  this PR bumps the baseline version to `2.332.1` and accordingly updates the BOM.

An existing test has been ignored as result, the last changes in `junit-plugin` made the test meaningless and the use case is a bit weird. See the linked PR in the `@ignore` annotation