### PR TITLE
create agents with labels pre-set

### DIFF
--- a/src/test/java/hudson/model/NodeTest.java
+++ b/src/test/java/hudson/model/NodeTest.java
@@ -53,8 +53,7 @@ public class NodeTest {
     @Issue("JENKINS-26391")
     @Test
     public void testGetAssignedLabelWithJobs() throws Exception {
-        final Node node = j.createOnlineSlave();
-        node.setLabelString("label1 label2");
+        final Node node = j.createSlave("label1 label2", null);
         MavenModuleSet mavenProject = j.jenkins.createProject(MavenModuleSet.class, "p");
         mavenProject.setAssignedLabel(j.jenkins.getLabel("label1"));
         RunLoadCounter.prepare(mavenProject);
@@ -78,10 +77,8 @@ public class NodeTest {
     @Issue("JENKINS-26391")
     @Test
     public void testGetAssignedLabelMultipleSlaves() throws Exception {
-        final Node node1 = j.createOnlineSlave();
-        node1.setLabelString("label1");
-        final Node node2 = j.createOnlineSlave();
-        node1.setLabelString("label1");
+        final Node node1 = j.createSlave("label1", null);
+        final Node node2 = j.createSlave("label1", null);
 
         MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "p1");
         final Label label = j.jenkins.getLabel("label1");
@@ -103,8 +100,7 @@ public class NodeTest {
     @Issue("JENKINS-26391")
     @Test
     public void testGetAssignedLabelWhenLabelRemoveFromProject() throws Exception {
-        final Node node = j.createOnlineSlave();
-        node.setLabelString("label1");
+        final Node node = j.createSlave("label1", null);
 
         MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "p");
         final Label label = j.jenkins.getLabel("label1");


### PR DESCRIPTION
calling setLabels on an agent will not persist the node.

in older versions of Jenkins the tests would be less flaky as adding any
Node would cause all labels to be re-evaluated, so when creating a few
agents and adding labels in a loop the last one created would at least
deterministically ensure that all previous agents labels where correct.

However since 2.332 (jenkinsci/jenkins#5882)
only labels part of a node added or removed would be updated, and when
creating the agents they where created without labels, which where added
later.

This caused tests to be flaky depending on when the periodic
trimLabels was called (or at least on other timing related things)

Additionally creating agents and waiting for them to come oneline is
slow. A job can be scheduled and will then wait for the node to be available,
so we can do other things whilst the agent is connecting.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
