### PR TITLE
Remove warning about the plugin being deprecated

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-This plug-in provides a deep integration of Jenkins and Maven: Automatic triggers between projects depending on SNAPSHOTs, automated configuration of various Jenkins publishers (Junit, ...).
-This plugin is deprecated and it's recommended to avoid using it.
+This plugin provides a deep integration between Jenkins and Maven. It adds support for automatic triggers between projects depending on SNAPSHOTs as well as the automated configuration of various Jenkins publishers such as Junit.
 </div>


### PR DESCRIPTION
As far as I know, this plugin is not actually deprecated, so having that sentence in the description is a bit confusing and misleading. If this Jenkins plugin is indeed deprecated, it should be marked as such using the official process shown here: https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/

I also rephrased the first sentence of the description a bit for clarity, feel free to change it further if you'd like or leave it as is.