### PR TITLE
Remove duplicate project page entries (workspace, recent changes, test result)

### DIFF
--- a/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
@@ -42,26 +42,10 @@ THE SOFTWARE.
             ${act.displayName}
           </t:summary>
         </j:forEach>
-        <t:summary icon="folder.svg" href="ws/" permission="${it.WORKSPACE}">
-          ${%Workspace}
-        </t:summary>
 
         <t:artifactList caption="${%Last Successful Artifacts}"
             build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
             permission="${it.lastSuccessfulBuild.ARTIFACTS}" />
-
-        <t:summary icon="notepad.svg" href="changes">
-          ${%Recent Changes}
-        </t:summary>
-
-        <j:set var="tr" value="${it.testResultAction}"/>
-        <j:if test="${tr!=null}">
-          <t:summary icon="clipboard.svg">
-            <a href="lastBuild/testReport/">${%Latest Test Result}</a>
-            <st:nbsp/>
-            <t:test-result it="${tr}" />
-          </t:summary>
-        </j:if>
       </table>
 
       <st:include page="jobpropertysummaries.jelly" />


### PR DESCRIPTION
The change proposed deduplicates entries on the project page. The maven plugin depends on the JUnit plugin to be installed, which already adds a link to the test results, the current implementation adds another one:
![a](https://user-images.githubusercontent.com/13383509/180738264-f1e28dcf-ffd7-407b-ad4f-ee8523967069.png)

