### PR TITLE
Create webclients using jth wrapper

### DIFF
--- a/src/test/java/hudson/maven/MavenProjectTest.java
+++ b/src/test/java/hudson/maven/MavenProjectTest.java
@@ -113,7 +113,7 @@ public class MavenProjectTest extends AbstractMavenTestCase {
         buildAndAssertSuccess(project);
 
         // this should succeed
-        HudsonTestCase.WebClient wc = new WebClient();
+        HudsonTestCase.WebClient wc = createWebClient();
         wc.getPage(project,"site");
         wc.assertFails(project.getUrl() + "site/no-such-file", HttpURLConnection.HTTP_NOT_FOUND);
     }
@@ -133,7 +133,7 @@ public class MavenProjectTest extends AbstractMavenTestCase {
         }
 
         // this should succeed
-        HudsonTestCase.WebClient wc = new WebClient();
+        HudsonTestCase.WebClient wc = createWebClient();
         wc.getPage(project, "site");
         wc.getPage(project, "site/core");
         wc.getPage(project, "site/client");
@@ -160,7 +160,7 @@ public class MavenProjectTest extends AbstractMavenTestCase {
         }
 
         // this should succeed
-        HudsonTestCase.WebClient wc = new WebClient();
+        HudsonTestCase.WebClient wc = createWebClient();
         wc.getPage(project, "site");
         wc.getPage(project, "site/core");
         wc.getPage(project, "site/client");
@@ -185,7 +185,7 @@ public class MavenProjectTest extends AbstractMavenTestCase {
         }
 
         // this should succeed
-        HudsonTestCase.WebClient wc = new WebClient();
+        HudsonTestCase.WebClient wc = createWebClient();
         wc.getPage(project, "site");
         wc.getPage(project, "site/core");
         wc.getPage(project, "site/client");

--- a/src/test/java/hudson/maven/RedeployPublisherTest.java
+++ b/src/test/java/hudson/maven/RedeployPublisherTest.java
@@ -81,7 +81,7 @@ public class RedeployPublisherTest {
         MavenModuleSet p = j.jenkins.createProject(MavenModuleSet.class, "p");
         RedeployPublisher rp = new RedeployPublisher("theId", "http://some.url/", true, true);
         p.getPublishersList().add(rp);
-        j.submit(j.new WebClient().getPage(p,"configure").getFormByName("config"));
+        j.submit(j.createWebClient().getPage(p,"configure").getFormByName("config"));
         j.assertEqualBeans(rp,p.getPublishersList().get(RedeployPublisher.class),"id,url,uniqueVersion,evenIfUnstable");
     }
 


### PR DESCRIPTION
see https://github.com/jenkinsci/jenkins-test-harness/pull/567#issuecomment-1493427893

A plugin shouldn't manually create the webclient, instead it should go through the wrapper method in the JTH API