### PR TITLE
Fixed NPE during reporting

### DIFF
--- a/src/main/java/hudson/maven/AbstractMavenBuilder.java
+++ b/src/main/java/hudson/maven/AbstractMavenBuilder.java
@@ -98,7 +98,13 @@ public abstract class AbstractMavenBuilder extends MasterToSlaveCallable<Result,
     void end(Launcher launcher) throws IOException, InterruptedException {
         for (Map.Entry<ModuleName,ProxyImpl2> e : sourceProxies.entrySet()) {
             ProxyImpl2 p = e.getValue();
-            for (MavenReporter r : reporters.get(e.getKey())) {
+            ModuleName module = e.getKey();
+			List<MavenReporter> moduleReporters = reporters.get(module);
+			if (moduleReporters == null) {
+				// Safety: Key set of reporter and source list has become inconsistent.
+				continue;
+			}
+			for (MavenReporter r : moduleReporters) {
                 // we'd love to do this when the module build ends, but doing so requires
                 // we know how many task segments are in the current build.
                 r.end(p.owner(),launcher,listener);

--- a/src/main/java/hudson/maven/AbstractMavenBuilder.java
+++ b/src/main/java/hudson/maven/AbstractMavenBuilder.java
@@ -99,12 +99,12 @@ public abstract class AbstractMavenBuilder extends MasterToSlaveCallable<Result,
         for (Map.Entry<ModuleName,ProxyImpl2> e : sourceProxies.entrySet()) {
             ProxyImpl2 p = e.getValue();
             ModuleName module = e.getKey();
-			List<MavenReporter> moduleReporters = reporters.get(module);
-			if (moduleReporters == null) {
-				// Safety: Key set of reporter and source list has become inconsistent.
-				continue;
-			}
-			for (MavenReporter r : moduleReporters) {
+            List<MavenReporter> moduleReporters = reporters.get(module);
+            if (moduleReporters == null) {
+                // Safety: Key set of reporter and source list has become inconsistent.
+                continue;
+            }
+            for (MavenReporter r : moduleReporters) {
                 // we'd love to do this when the module build ends, but doing so requires
                 // we know how many task segments are in the current build.
                 r.end(p.owner(),launcher,listener);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

There is evidence that the key sets of the sourceProxies and reporters
maps get inconsistent. I observe randomly failing builds that report the
following error:

```
FATAL: Cannot invoke "java.util.List.iterator()" because the return
value of "java.util.Map.get(Object)" is null
java.lang.NullPointerException: Cannot invoke
"java.util.List.iterator()" because the return value of
"java.util.Map.get(Object)" is null
	at hudson.maven.AbstractMavenBuilder.end(AbstractMavenBuilder.java:101)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.doRun(MavenModuleSetBuild.java:883)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:526)
	at hudson.model.Run.execute(Run.java:1895)
	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:543)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
```

The fix skips reporting for modules no reporters have been collected for. 

Problem has been reported here: https://issues.jenkins.io/browse/JENKINS-72090

### Testing done

The reason for the problem is not know, the fix provided here is only a safety mechanism that prevents the build to fail. There is no known test that triggers the problem.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
