### PR TITLE
Replaced deprecated `NullStream` and `Jenkins.getInstance()` with suggested replacements

### DIFF
--- a/src/main/java/hudson/maven/AbstractMavenBuilder.java
+++ b/src/main/java/hudson/maven/AbstractMavenBuilder.java
@@ -151,7 +151,7 @@ public abstract class AbstractMavenBuilder extends MasterToSlaveCallable<Result,
 
     // since reporters might be from plugins, use the uberjar to resolve them.
     public ClassLoader getClassLoader() {
-        return Jenkins.getInstance().getPluginManager().uberClassLoader;
+        return Jenkins.get().getPluginManager().uberClassLoader;
     }
 
     /**

--- a/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/src/main/java/hudson/maven/MavenModuleSet.java
@@ -315,7 +315,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         // backward compatibility, maven-plugin used to have a dependency to the config-file-provider plugin
         Plugin plugin = null;
         if(StringUtils.isNotBlank(this.settingConfigId) || StringUtils.isNotBlank(this.globalSettingConfigId)) {
-            plugin = Jenkins.getInstance().getPlugin("config-file-provider");
+            plugin = Jenkins.get().getPlugin("config-file-provider");
             if(plugin == null || !plugin.getWrapper().isEnabled()){
                 LOGGER.severe(Messages.MavenModuleSet_readResolve_missingConfigProvider());
             }  
@@ -391,7 +391,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      *      Use {@link #MavenModuleSet(ItemGroup, String)}
      */
     public MavenModuleSet(String name) {
-        this(Jenkins.getInstance(), name);
+        this(Jenkins.get(), name);
     }
 
     public MavenModuleSet(ItemGroup parent, String name) {
@@ -1153,14 +1153,14 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      * Returns the {@link MavenModule}s that are in the queue.
      */
     public List<Queue.Item> getQueueItems() {
-        return filter(Arrays.asList(Jenkins.getInstance().getQueue().getItems()));
+        return filter(Arrays.asList(Jenkins.get().getQueue().getItems()));
     }
 
     /**
      * Returns the {@link MavenModule}s that are in the queue.
      */
     public List<Queue.Item> getApproximateQueueItemsQuickly() {
-        return filter(Jenkins.getInstance().getQueue().getApproximateItemsQuickly());
+        return filter(Jenkins.get().getQueue().getApproximateItemsQuickly());
     }
 
     private List<Queue.Item> filter(Collection<Queue.Item> base) {
@@ -1293,7 +1293,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
     }
 
     public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl)Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (DescriptorImpl)Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -1054,7 +1054,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
             // we might have added new modules
             if (needsDependencyGraphRecalculation) {
                 logger.println("Modules changed, recalculating dependency graph");
-                Jenkins.getInstance().rebuildDependencyGraph();
+                Jenkins.get().rebuildDependencyGraph();
             }
 
             // module builds must start with this build's number

--- a/src/main/java/hudson/maven/MojoInfo.java
+++ b/src/main/java/hudson/maven/MojoInfo.java
@@ -41,7 +41,6 @@ import org.codehaus.plexus.component.configurator.ComponentConfigurationExceptio
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Method;
 

--- a/src/main/java/hudson/maven/ProcessCache.java
+++ b/src/main/java/hudson/maven/ProcessCache.java
@@ -35,7 +35,6 @@ import hudson.remoting.VirtualChannel;
 import hudson.remoting.RequestAbortedException;
 import hudson.tasks.Maven.MavenInstallation;
 import hudson.util.DelegatingOutputStream;
-import hudson.util.NullStream;
 import jenkins.security.MasterToSlaveCallable;
 
 import java.io.IOException;
@@ -132,7 +131,7 @@ public final class ProcessCache {
             if(age>=MAX_AGE || maxProcess==0)
                 discard();
             else {
-                output.set(new NullStream());
+                output.set(OutputStream.nullOutputStream());
                 // make room for the new process and reuse.
                 synchronized(parent.processes) {
                     while(parent.processes.size()>=maxProcess)

--- a/src/main/java/hudson/maven/SplittableBuildListener.java
+++ b/src/main/java/hudson/maven/SplittableBuildListener.java
@@ -43,7 +43,6 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutionException;

--- a/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -6,7 +6,6 @@ import hudson.maven.MojoInfo;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -16,7 +15,6 @@ import org.apache.tools.ant.types.FileSet;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 
 /**

--- a/src/test/java/hudson/maven/Maven36xBuildTest.java
+++ b/src/test/java/hudson/maven/Maven36xBuildTest.java
@@ -43,7 +43,7 @@ public class Maven36xBuildTest
         Maven.MavenInstallation mvn = ToolInstallations.configureDefaultMaven("apache-maven-3.6.3", MavenInstallation.MAVEN_30);
 
         Maven.MavenInstallation m3 = new Maven.MavenInstallation( "apache-maven-3.6.3", mvn.getHome(), JenkinsRule.NO_PROPERTIES);
-        Jenkins.getInstance().getDescriptorByType( Maven.DescriptorImpl.class).setInstallations( m3);
+        Jenkins.get().getDescriptorByType( Maven.DescriptorImpl.class).setInstallations( m3);
         return m3;
     }
 

--- a/src/test/java/hudson/maven/MavenProjectTest.java
+++ b/src/test/java/hudson/maven/MavenProjectTest.java
@@ -72,7 +72,7 @@ public class MavenProjectTest extends AbstractMavenTestCase {
         project.setGoals("abcdefg");
         project.save();
         
-        MavenModuleSet copy = (MavenModuleSet) Jenkins.getInstance().copy((AbstractProject<?, ?>)project, "copy" + System.currentTimeMillis());
+        MavenModuleSet copy = (MavenModuleSet) Jenkins.get().copy((AbstractProject<?, ?>)project, "copy" + System.currentTimeMillis());
         assertNotNull("Copied project must not be null", copy);
         assertEquals(project.getGoals(), copy.getGoals());
     }

--- a/src/test/java/hudson/maven/reporters/MavenMailerTest.java
+++ b/src/test/java/hudson/maven/reporters/MavenMailerTest.java
@@ -51,7 +51,6 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.mock_javamail.Mailbox;
 
 import java.util.List;
@@ -94,7 +93,7 @@ public class MavenMailerTest {
 
     public Mailbox runMailTest(boolean perModuleEamil) throws Exception {
 
-        final DescriptorImpl mailDesc = Jenkins.getInstance().getDescriptorByType(Mailer.DescriptorImpl.class);
+        final DescriptorImpl mailDesc = Jenkins.get().getDescriptorByType(Mailer.DescriptorImpl.class);
 
         // intentionally give the whole thin in a double quote
         Mailer.descriptor().setAdminAddress(EMAIL_ADMIN);


### PR DESCRIPTION
Replaced deprecated `NullStream` and `Jenkins.getInstance()` with suggested replacements and removed unused imports.

### Testing done

Started the application with `hpi:run` configured a maven tool and created a maven job which just executed a minimal pom.xml
All without noticing any problems.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
