### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/hudson/maven/AbstractMavenProcessFactory.java
+++ b/src/main/java/hudson/maven/AbstractMavenProcessFactory.java
@@ -34,7 +34,7 @@ import jenkins.security.MasterToSlaveCallable;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Zip;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;

--- a/src/main/java/hudson/maven/MavenBuild.java
+++ b/src/main/java/hudson/maven/MavenBuild.java
@@ -98,7 +98,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import jenkins.model.ArtifactManager;
 import jenkins.mvn.SettingsProvider;

--- a/src/main/java/hudson/maven/ModuleName.java
+++ b/src/main/java/hudson/maven/ModuleName.java
@@ -23,6 +23,8 @@
  */
 package hudson.maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.model.Plugin;
@@ -31,7 +33,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.ReportPlugin;
 
 import java.io.Serializable;
-import javax.annotation.Nonnull;
 
 /**
  * Version independent name of a Maven project. GroupID+artifactId.
@@ -40,8 +41,8 @@ import javax.annotation.Nonnull;
  * @see ModuleDependency
  */
 public class ModuleName implements Comparable<ModuleName>, Serializable {
-    public final @Nonnull String groupId;
-    public final @Nonnull String artifactId;
+    public final @NonNull String groupId;
+    public final @NonNull String artifactId;
 
     public ModuleName(String groupId, String artifactId) {
         if (groupId == null) {

--- a/src/main/java/hudson/maven/MojoInfo.java
+++ b/src/main/java/hudson/maven/MojoInfo.java
@@ -44,7 +44,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Method;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import hudson.util.InvocationInterceptor;
 import hudson.util.ReflectionUtils;

--- a/src/main/java/hudson/maven/PomInfo.java
+++ b/src/main/java/hudson/maven/PomInfo.java
@@ -23,6 +23,8 @@
  */
 package hudson.maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.CiManagement;
 import org.apache.maven.model.Dependency;
@@ -40,8 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * Serializable representation of the key information obtained from Maven POM.
@@ -56,7 +57,7 @@ final class PomInfo implements Serializable {
     
     public static final String PACKAGING_TYPE_PLUGIN = "maven-plugin";
 
-    public final @Nonnull ModuleName name;
+    public final @NonNull ModuleName name;
 
     /**
      * This is a human readable name of the POM. Not necessarily unique

--- a/src/main/java/hudson/maven/TcpSocketHostLocator.java
+++ b/src/main/java/hudson/maven/TcpSocketHostLocator.java
@@ -3,7 +3,7 @@ package hudson.maven;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
 import java.util.List;
 

--- a/src/main/java/hudson/maven/reporters/MavenArtifact.java
+++ b/src/main/java/hudson/maven/reporters/MavenArtifact.java
@@ -24,6 +24,7 @@
 package hudson.maven.reporters;
 
 import com.google.common.collect.Maps;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenBuildProxy;
@@ -42,7 +43,6 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -236,7 +236,7 @@ public final class MavenArtifact implements Serializable {
      * @return a representation of the artifact
      * @since 2.0.3
      */
-    public @Nonnull TemporaryFile getTemporaryFile(MavenBuild build) {
+    public @NonNull TemporaryFile getTemporaryFile(MavenBuild build) {
         return new TemporaryFile(build);
     }
 
@@ -259,7 +259,7 @@ public final class MavenArtifact implements Serializable {
          * This is the preferred method for code that does not need to deal with {@link File} specifically.
          * @return the purported location of the artifact (might no longer exist if it has since been deleted)
          */
-        public @Nonnull VirtualFile getVirtualFile() {
+        public @NonNull VirtualFile getVirtualFile() {
             return build.getArtifactManager().root().child(artifactPath());
         }
 
@@ -268,7 +268,7 @@ public final class MavenArtifact implements Serializable {
          * You must {@link #close} it when finished; do not delete the result file yourself.
          * @return either the original artifact, or a copy thereof; may not exist if it has since been deleted
          */
-        public @Nonnull synchronized File getFile() throws IOException {
+        public @NonNull synchronized File getFile() throws IOException {
             if (copy == null) {
                 try {
                     return MavenArtifact.this.getFile(build);

--- a/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -1,5 +1,5 @@
 package hudson.maven.reporters;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.maven.MojoInfo;
 
@@ -7,8 +7,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.types.FileSet;
@@ -183,7 +182,7 @@ enum TestMojo {
      * @return The directory containing the test reports.
      * @throws ComponentConfigurationException if unable to retrieve the report directory from the MOJO configuration.
      */
-    @Nonnull protected File getReportsDirectory(MavenProject pom, MojoInfo mojo) throws ComponentConfigurationException {
+    @NonNull protected File getReportsDirectory(MavenProject pom, MojoInfo mojo) throws ComponentConfigurationException {
         // [JENKINS-31258] Allow unknown MOJOs to contribute test results in arbitrary locations by setting a Maven property.
         String reportsDirectoryOverride = getReportsDirectoryOverride(mojo);
         if (reportsDirectoryOverride != null)


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
