### PR TITLE
Core minimum upgrade to 2.440.3 and useversion from plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>4.87</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.440.x</artifactId>
-        <version>3234.v5ca_5154341ef</version>
+        <version>3307.v2769886db_63b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -814,7 +814,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>957.vf5b_cee587563</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Rely on promoted-builds version from plugin BOM

Rely on promoted-builds from bom 3307.v2769886db_63b_

[Plugin BOM 3307.x](https://github.com/jenkinsci/bom/releases/tag/3307.v2769886db_63b_) now manages the promoted builds plugin version.  This pom can no longer needs to specify the version of promoted builds plugin.

[BOM issue 3171](https://github.com/jenkinsci/bom/issues/3171) describes some of the reasons why that benefits this plugin and why it benefits the plugin BOM maintainers.

* https://github.com/jenkinsci/bom/pull/3502

Also includes the pull request:

* https://github.com/jenkinsci/maven-plugin/pull/336

59% of installations of the most recent release of the plugin are already using Jenkins 2.440.3 or newer.  Users that are upgrading the plugin are also upgrading their Jenkins controller.

Also updates parent pom to 4.87 to use most recent tooling.

This does not need an immediate release.  Once it is merged, it will reduce dependabot noise, but a release is not required.

### Testing done

Confirmed that automated tests pass.  Rely on ci.jenkins.io for additional tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
