### PR TITLE
[JENKINS-73879] Remove inline JS for `rootPOM` validation

### DIFF
--- a/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -89,7 +89,7 @@ THE SOFTWARE.
     </j:if>
     <f:entry title="${%Root POM}" help="/plugin/maven-plugin/root-pom.html">
       <f:textbox name="rootPOM" value="${it.rootPOM}"
-              checkUrl="'checkFileInWorkspace?value='+escape(this.value)" />
+              checkUrl="checkFileInWorkspace" checkDependsOn="" />
     </f:entry>
     <f:entry title="${%Goals and options}" help="/plugin/maven-plugin/goals.html">
       <f:textbox name="goals" value="${it.userConfiguredGoals}"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

I thought recording a video for such change would be an overkill, so I'll provide some screenshots. Let me know if it's enough.

#### Before the change
Each time I trigger a validation on the `rootPOM` field on the configuration page of a Maven Project an error in the console appears:
![image](https://github.com/user-attachments/assets/db80d7a9-98f4-402e-986d-42c24cf8ffe5)

Checking the Content Security Policy report (provided by [Content Security Policy](https://plugins.jenkins.io/csp/)) we can see there's a violation:
![image](https://github.com/user-attachments/assets/cd2bc4c6-ce5b-4b8d-a669-1901b9b95772)

Parameter received on the server side:
![image](https://github.com/user-attachments/assets/6f1168ad-0974-45ac-acd9-cbbe982e6b32)


#### After the change

Triggering validation multiple times on the project configuration page yields no errors in the console:
![image](https://github.com/user-attachments/assets/788ccdbc-13a7-4588-b312-d9f0d0163ff7)

Content Security Policy report remains clear:
![image](https://github.com/user-attachments/assets/8507702e-12ea-461e-bce3-321b2be35474)

Value of the parameter is still received correctly by the server:
![image](https://github.com/user-attachments/assets/8f89eaa2-f411-4285-9992-a89a7bde9f23)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
