### PR TITLE
Exclude Maven dependencies from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,29 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    open-pull-requests-limit: 25
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # An upgrade of the Maven dependencies for this plugin would require
+      # significant build work and compatibility testing.
+      - dependency-name: "org.apache.maven:apache-maven"
+      - dependency-name: "org.apache.maven:maven-compat"
+      - dependency-name: "org.apache.maven:maven-core"
+      - dependency-name: "org.apache.maven:maven-embedder"
+      - dependency-name: "org.apache.maven:maven-repository-metadata"
+      - dependency-name: "org.apache.maven:maven-resolver-provider"
+      - dependency-name: "org.apache.maven.reporting:maven-reporting-api"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-api"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-connector-basic"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-impl"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-spi"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-transport-wagon"
+      - dependency-name: "org.apache.maven.resolver:maven-resolver-util"
+      - dependency-name: "org.codehaus.plexus:plexus-cipher"
+      - dependency-name: "org.codehaus.plexus:plexus-classworlds"
+      - dependency-name: "org.codehaus.plexus:plexus-component-annotations"
+      - dependency-name: "org.codehaus.plexus:plexus-utils"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
These dependencies are not immediately actionable, as they require a lot of build work and compatibility testing. In the meantime, they are preventing us from effectively processing updates to normal dependencies, like the plugin parent POM and BOM. Exclude them for now until we have time to do the build work and compatibility testing needed to upgrade Maven in this plugin.