### PR TITLE
Increase timeout for CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
-buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+buildPlugin(
+  timeout: 120, // reduce test failures due to timeout
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
https://ci.jenkins.io/job/Plugins/job/maven-plugin/job/PR-372/1/console timed out on the new (old) Windows ACI agents, so give this test suite more time.