### PR TITLE
Use jsoup API plugin instead of jsoup library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4051.v78dce3ce8b_d6</version>
+        <version>4228.v0a_71308d905b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ THE SOFTWARE.
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <mavenInterceptorsVersion>1.14</mavenInterceptorsVersion>
     <!--
       Minimal supported version of Maven.
@@ -576,9 +576,8 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jsoup</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use jsoup API plugin instead of jsoup library

Use the same version of jsoup throughout Jenkins.

Also updates the required Jenkins version to 2.479.3 instead of 2.479.1 as recommended by ["Choosing a Jenkins version ..."](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

Includes pull request:

* #375

This pull request should be labeled `maintenance` but I did not have permission to assign the label.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.  Rely on ci.jenkins.io to test Windows with Java 17.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
