### PR TITLE
Fixing slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <url>https://github.com/jenkinsci/${project.artifactId}</url>
 
   <properties>
-    <revision>3.28</revision>
+    <revision>3.28.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->


### PR DESCRIPTION
- Change ExecutionEventLogger constructor to call super() instead of super(logger)
- Prevents loader constraint violation between Jenkins controller slf4j and Maven plexus.core slf4j
- Fixes Maven job type failure during 'Parsing POMs' phase with Jenkins 2.492.3 + Maven 3.9.x (And others)
- Bump version to 3.28.1-SNAPSHOT"